### PR TITLE
Menu Bar Icons Too Narrow

### DIFF
--- a/src/app/components/MapControlBar.tsx
+++ b/src/app/components/MapControlBar.tsx
@@ -28,7 +28,8 @@ const SearchBarComponent: React.FC<MapControlBarProps> = ({
   };
 
   return (
-    <div className="flex items-center space-x-2 bg-white p-2 h-12">
+    <div className="flex items-center space-x-2 bg-white p-2 h-12"
+      style={{ minWidth: "500px" }}>
       <Button className="bg-white" onClick={toggleDetailView}>
         {currentView === "detail" ? (
           <ListBulletIcon className="h-6 w-6" />


### PR DESCRIPTION
Fixes [Issue 94](https://github.com/CodeForPhilly/vacant-lots-proj/issues/94) by setting a minimum pixel width for the search bar. 
Visible on the [map](http://localhost:3000/map) page.
Before:
<img width="577" alt="image" src="https://github.com/CodeForPhilly/vacant-lots-proj/assets/125047199/53aa26ae-ec37-4573-9ed6-759c579838b9">
After:
<img width="575" alt="image" src="https://github.com/CodeForPhilly/vacant-lots-proj/assets/125047199/95a6ac1e-d11e-4694-951d-3077385a7911">
