### PR TITLE
Issue #119: Add link to atlas to property cards

### DIFF
--- a/src/app/components/PropertyCard.tsx
+++ b/src/app/components/PropertyCard.tsx
@@ -12,6 +12,7 @@ const PropertyCard = ({ feature, setSelectedProperty }: PropertyCardProps) => {
 
   const roundedCanopyGap = Math.round(tree_canopy_gap * 100);
   const randomImage = `/image1.jpg`;
+  const atlasUrl = `https://atlas.phila.gov/${ADDRESS}`;
 
   return (
     <div

--- a/src/app/components/PropertyCard.tsx
+++ b/src/app/components/PropertyCard.tsx
@@ -33,6 +33,7 @@ const PropertyCard = ({ feature, setSelectedProperty }: PropertyCardProps) => {
             <div className="text-gray-700 mb">
               {guncrime_density} Crime Rate, {roundedCanopyGap}% Canopy Gap
             </div>
+            <a href={atlasUrl} target="_blank" rel="noopener noreferrer">Click here for Atlas Info</a>
           </div>
           <div className="px-4 pb-2">
             <Chip color="success" variant="solid" size="sm">


### PR DESCRIPTION
### Summary
This PR introduces a new feature in the `PropertyCard` component, adding a direct hyperlink to the City's Atlas website for each listed property.

### Changes
- An anchor (`<a>`) tag was added to include a hyperlink in the property card.
- The URL for the hyperlink is dynamically generated using the property address and concatenating it with the base URL of the City's Atlas website.
- The hyperlink opens in a new tab (`target="_blank"`) for better user experience and includes `rel="noopener noreferrer"` for improved security.

### Code Snippets
```
//Added this line:
const atlasUrl = `https://atlas.phila.gov/${ADDRESS}`;
```
```
<div className="p-4">
            <div className="font-bold text-xl">{ADDRESS}</div>
            <div className="text-gray-700 mb">
              {guncrime_density} Crime Rate, {roundedCanopyGap}% Canopy Gap
            </div>
            // Added this line
            <a href={atlasUrl} target="_blank" rel="noopener noreferrer">Click here for Atlas Info</a>
          </div>
```
### Rationale
- Enhanced User Experience: By providing a direct link to the City's Atlas website, users can easily access more detailed information about each property.

- Dynamic URL Generation: The URL is generated dynamically for each property, ensuring that the link is always accurate and specific to the property being viewed.

If this isn't want you wanted, let me know an I will go back and fix it. 
Thanks for letting me contribute!