### PR TITLE
feat: Add font to search field

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -48,7 +48,7 @@
   }
 }
 
-.customized-map * {
+.customized-map *, .customized-map .mapboxgl-ctrl-geocoder--input {
   @apply font-body;
 }
 


### PR DESCRIPTION
This PR updates the font in the search field to HK Grotesk, like the rest of the site.
<img width="292" alt="Screenshot 2024-01-23 at 9 25 29 PM" src="https://github.com/CodeForPhilly/vacant-lots-proj/assets/4121678/0ac54957-e16c-43b3-bbcb-55f651b3e7c2">
