### PR TITLE
fix: increase link hitbox size

### DIFF
--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -57,14 +57,14 @@ const Header = () => (
           </Button>
         </DropdownTrigger>
         <DropdownMenu aria-label="Take Action">
-          <DropdownItem key="overview">
-            <Link href="/take-action-overview">Overview</Link>
+          <DropdownItem href="/take-action-overview">
+            Overview
           </DropdownItem>
-          <DropdownItem key="get-access">
-            <Link href="/get-access">Get Access</Link>
+          <DropdownItem href="/get-access">
+            Get Access
           </DropdownItem>
-          <DropdownItem key="transform-property">
-            <Link href="/transform-property">Transform a Property</Link>
+          <DropdownItem href="/transform-property">
+            Transform a Property
           </DropdownItem>
         </DropdownMenu>
       </Dropdown>
@@ -81,11 +81,11 @@ const Header = () => (
           </Button>
         </DropdownTrigger>
         <DropdownMenu aria-label="Overview">
-          <DropdownItem key="about">
-            <Link href="/about">Overview</Link>
+          <DropdownItem href="/about">
+            Overview
           </DropdownItem>
-          <DropdownItem key="methodology">
-            <Link href="/methodology">Methodology</Link>
+          <DropdownItem href="/methodology">
+            Methodology
           </DropdownItem>
         </DropdownMenu>
       </Dropdown>


### PR DESCRIPTION
This PR increases the size of the hitbox of the clickable header links by adding the `href` property to the dropdown, resolving #278.

Before:
<img width="216" alt="Screenshot 2024-02-08 at 8 54 58 PM" src="https://github.com/CodeForPhilly/vacant-lots-proj/assets/4121678/b088a487-cff6-424d-988e-2fcd69723134">

After:
<img width="215" alt="Screenshot 2024-02-08 at 8 55 14 PM" src="https://github.com/CodeForPhilly/vacant-lots-proj/assets/4121678/dcf4aa31-76b5-4227-9816-c60b86c5da9a">
