### PR TITLE
311-196/ Main element on each page, add skip link

### DIFF
--- a/src/app/components/Layout.tsx
+++ b/src/app/components/Layout.tsx
@@ -12,8 +12,11 @@ interface LayoutProps {
 const Layout: FC<LayoutProps> = ({ children }) => {
   return (
     <div className="h-screen">
+      <a className="font-bold border-solid border-black bg-white transition left-0 absolute p-3 m-3 -translate-y-16 focus:translate-y-0 z-50" href="#main" tabIndex={0}>Skip to main content</a>
       <Header />
-      {children}
+      <main id="main">
+        {children}
+      </main>
       <Footer />
       <Hotjar />
     </div>

--- a/src/app/map/page.tsx
+++ b/src/app/map/page.tsx
@@ -28,8 +28,9 @@ const Page: FC = () => {
     <FilterProvider>
       <NextUIProvider>
         <div className="flex flex-col h-screen">
+          <a className="font-bold border-solid border-black bg-white transition left-0 absolute p-3 m-3 -translate-y-16 focus:translate-y-0 z-50" href="#main" tabIndex={0}>Skip to main content</a>
           <Header />
-          <div className="flex flex-grow overflow-hidden">
+          <main className="flex flex-grow overflow-hidden" id="main">
             <div className="flex-grow overflow-auto">
               <PropertyMap
                 setFeaturesInView={setFeaturesInView}
@@ -85,7 +86,7 @@ const Page: FC = () => {
                 </>
               )}
             </SidePanel>
-          </div>
+          </main>
           <Hotjar />
         </div>
       </NextUIProvider>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,10 +11,11 @@ const Page: FC = () => {
   return (
     <NextUIProvider>
       <div className="flex flex-col min-h-screen overflow-hidden">
+      <a className="font-bold border-solid border-black bg-white transition left-0 absolute p-3 m-3 -translate-y-16 focus:translate-y-0 z-50" href="#main" tabIndex={0}>Skip to main content</a>
         <Header />
-        <div className="flex-grow">
+        <main id="main" className="flex-grow">
           <LandingPage />
-        </div>
+        </main>
         <Footer />
         <Hotjar />
       </div>


### PR DESCRIPTION
For 
https://github.com/CodeForPhilly/vacant-lots-proj/issues/331
https://github.com/CodeForPhilly/vacant-lots-proj/issues/196

Should now be a main tag + skip link on every page

### Testing
Open up the app and TAB. You may have to TAB + SHIFT backwards past the logo in the header. Skip link should pop up. If you press ENTER, focus will be moved down into the main element.  TAB again and you'll see that you've skipped the other nav items and focus is in the main content.

<img width="312" alt="Screenshot 2024-02-25 at 12 31 20 PM" src="https://github.com/CodeForPhilly/vacant-lots-proj/assets/7329799/075716d4-7710-45f8-9dd7-c704aa2c46da">
