### PR TITLE
Gturmel/308 update pagination when page overflows

### DIFF
--- a/src/app/components/PropertyDetailSection.tsx
+++ b/src/app/components/PropertyDetailSection.tsx
@@ -53,6 +53,10 @@ const PropertyDetailSection: FC<PropertyDetailSectionProps> = ({
     const start = (page - 1) * rowsPerPage;
     const end = start + rowsPerPage;
 
+    if (start > featuresInView.length) {
+      setPage(1);
+    }
+
     return featuresInView.slice(start, end);
   }, [page, featuresInView]);
 


### PR DESCRIPTION
Closes #[308](https://github.com/CodeForPhilly/vacant-lots-proj/issues/308)  

If the user selects a page (example, 17), and then enters an address, the map will zoom in. If the resulting map section doesn't have enough results to populate to that page, the sidebar will be blank.

This checks the length of the `featuresInView` array against the `start` index. If the start is larger than the length of the `features` array, reset to the first page.