### PR TITLE
A11y: All links should use blue #0070F0

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -62,5 +62,5 @@
 }
 
 .link {
-  @apply text-primary underline;
+  @apply text-[#0070F0] underline;
 }


### PR DESCRIPTION
Updated the global.css file to change the link color to  #0070F0 instead of #3B82F6. 
Issue can be found here: https://github.com/CodeForPhilly/vacant-lots-proj/issues/332