### PR TITLE
feat(305): expand the header width of single property table

### DIFF
--- a/src/app/components/SinglePropertyDetail.tsx
+++ b/src/app/components/SinglePropertyDetail.tsx
@@ -54,6 +54,12 @@ const SinglePropertyDetail = ({
     ? "bg-priority-low"
     : "";
 
+  const Th = ({ children }: { children: React.ReactNode }) => (
+    <th scope="row" className="table-cell whitespace-nowrap w-1/3">
+      {children}
+    </th>
+  );
+
   return (
     <div
       className="w-full p-4"
@@ -116,9 +122,7 @@ const SinglePropertyDetail = ({
           }}
         >
           <tr>
-            <th scope="row" className="table-cell w-3/12">
-              Suggested Priority
-            </th>
+            <Th>Suggested Priority</Th>
             <td className="table-cell">
               <div className="flex gap-1 items-center">
                 <span
@@ -129,15 +133,11 @@ const SinglePropertyDetail = ({
             </td>
           </tr>
           <tr>
-            <th scope="row" className="table-cell">
-              Gun Crime Rate
-            </th>
+            <Th>Gun Crime Rate</Th>
             <td className="table-cell">{guncrime_density}</td>
           </tr>
           <tr>
-            <th scope="row" className="table-cell">
-              Tree Canopy Gap
-            </th>
+            <Th>Tree Canopy Gap</Th>
             <td className="table-cell">{Math.round(tree_canopy_gap * 100)}%</td>
           </tr>
         </tbody>
@@ -146,62 +146,44 @@ const SinglePropertyDetail = ({
       <table className="w-full mb-4">
         <tbody>
           <tr style={{ display: "none" }}>
-            <th scope="row" className="table-cell w-3/12">
-              Access Process
-            </th>
+            <Th>Access Process</Th>
             <td className="table-cell">{access_process}</td>
           </tr>
           <tr>
-            <th scope="row" className="table-cell w-3/12">
-              Owner
-            </th>
+            <Th>Owner</Th>
             <td className="table-cell">
               <p>{owner_1}</p>
               {owner_2 && <p>{owner_2}</p>}
             </td>
           </tr>
           <tr>
-            <th scope="row" className="table-cell">
-              Parcel Type
-            </th>
+            <Th>Parcel Type</Th>
             <td className="table-cell">
               <p>{parcel_type}</p>
             </td>
           </tr>
           <tr>
-            <th scope="row" className="table-cell">
-              Zip Code
-            </th>
+            <Th>Zip Code</Th>
             <td className="table-cell">{zipcode}</td>
           </tr>
           <tr>
-            <th scope="row" className="table-cell">
-              RCO
-            </th>
+            <Th>RCO</Th>
             <td className="table-cell">{neighborhood}</td>
           </tr>
           <tr>
-            <th scope="row" className="table-cell">
-              Council District
-            </th>
+            <Th>Council District</Th>
             <td className="table-cell">{council_district}</td>
           </tr>
           <tr>
-            <th scope="row" className="table-cell">
-              Market Value
-            </th>
+            <Th>Market Value</Th>
             <td className="table-cell">${market_value.toLocaleString()}</td>
           </tr>
           <tr>
-            <th scope="row" className="table-cell">
-              Tax Delinquency
-            </th>
+            <Th>Tax Delinquency</Th>
             <td className="table-cell">{total_due ? "Yes" : "No"}</td>
           </tr>
           <tr>
-            <th scope="row" className="table-cell">
-              L&I Violations
-            </th>
+            <Th>L&I Violations</Th>
             <td className="table-cell">{open_violations_past_year}</td>
           </tr>
         </tbody>


### PR DESCRIPTION
## Description
This PR adds styling to stop the Single Property view's table headers from wrapping when the viewport gets too narrow.

## Testing
From `/map`, click into a single property, and observe the text wrapping headers as you shrink/expand the viewport width.

#### Before (at 1200px viewport)
<img width="1199" alt="image" src="https://github.com/CodeForPhilly/vacant-lots-proj/assets/8061917/5f458ae0-a801-4388-bfa8-e25668860155">

#### After (at 760px viewport)
<img width="760" alt="Screenshot 2024-03-05 at 2 28 05 AM" src="https://github.com/CodeForPhilly/vacant-lots-proj/assets/8061917/a7c8202a-5406-4225-903a-0939b965d947">

#### After (at 1200px viewport)
<img width="1201" alt="image" src="https://github.com/CodeForPhilly/vacant-lots-proj/assets/8061917/ed97c87b-52aa-4b20-b0f8-80c4ab95d2e6">


Closes #305 