### PR TITLE
feat(293): sort features by priority of high, medium, low

### DIFF
--- a/src/app/components/PropertyMap.tsx
+++ b/src/app/components/PropertyMap.tsx
@@ -153,8 +153,23 @@ const PropertyMap: FC<PropertyMapProps> = ({
 
     setFeatureCount(features.length);
 
+    const priorities: { [key: string]: number } = {
+      High: 1,
+      Medium: 2,
+      Low: 3,
+    };
+
+    const sortedFeatures = features
+      .sort((a, b) => {
+        return (
+          priorities[a?.properties?.priority_level || ""] -
+          priorities[b?.properties?.priority_level || ""]
+        );
+      })
+      .slice(0, 100);
+
     // only set the first 100 properties in state
-    setFeaturesInView(features.slice(0, 100));
+    setFeaturesInView(sortedFeatures);
     setLoading(false);
   };
 


### PR DESCRIPTION
## Description
This PR naively sorts the features based on their `priority_value` of "High", "Medium", or "Low".

## Testing
In the main map at `/map`, zoom tightly into a cross street with all three priority values (of orange, yellow, and green), and see in the filtered results that the properties with the "High Priority" labels are first, with "Medium Priority" second, and "Low" last.

For this example I used N 16th and W Westmoreland, but any set should do.

#### Before
<img width="1149" alt="image" src="https://github.com/CodeForPhilly/vacant-lots-proj/assets/8061917/ea5d8578-8af4-4b39-bce0-3e9e972589f9">

#### After
<img width="1152" alt="image" src="https://github.com/CodeForPhilly/vacant-lots-proj/assets/8061917/a487b787-b343-40df-8fb0-c802614e8e23">


Closes #293