### PR TITLE
feat(247): make the mapbox legend more legible

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -64,3 +64,18 @@
 .link {
   @apply text-primary underline;
 }
+
+/* Styles for the mapbox legend pane. */
+.mapboxgl-ctrl-legend-pane summary {
+  text-transform: capitalize;
+}
+
+.mapboxgl-ctrl-legend-pane ul.list li {
+  text-transform: capitalize;
+  color: #173009;
+}
+
+/* Crude way to hide the last "Other" legend item. */
+.mapboxgl-ctrl-legend-pane ul.list li:last-child {
+  display: none;
+}


### PR DESCRIPTION
## Description
This PR updates the mapbox legend to be capitalized and darker. Due to the way this simply linking to the provided mapbox css, it is admittedly very, very brittle — but given that it's understood that it's a ducttape solution, I'll leave it up to the owners of this project to determine if they'd like to merge it in or not.

## Testing
View the map legend on the main page at `/map`.

#### Before
<img width="183" alt="image" src="https://github.com/CodeForPhilly/vacant-lots-proj/assets/8061917/51d7f45b-41f5-4f6e-9c1a-b484329fff08">

#### After
<img width="189" alt="image" src="https://github.com/CodeForPhilly/vacant-lots-proj/assets/8061917/b28f8992-c9f2-4b11-bb59-40798e90ae4d">


Related to (but technically doesn't close) #247