### PR TITLE
feat(279): refactor text styles and add enforcement via eslint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaVersion": 2020,
+    "sourceType": "module",
+    "project": "./tsconfig.json"
+  },
+  "plugins": [
+    "eslint-plugin-custom-rules"
+  ],
+  "rules": {
+    "custom-rules/no-text-size-class": "warn"
+  },
+  "ignorePatterns": [
+    "next.config.js",
+    "postcss.config.js"
+  ]
+}

--- a/eslint-plugin-custom-rules/index.js
+++ b/eslint-plugin-custom-rules/index.js
@@ -1,0 +1,5 @@
+module.exports = {
+  rules: {
+    "no-text-size-class": require("./rules/no-text-size-class"),
+  },
+};

--- a/eslint-plugin-custom-rules/package.json
+++ b/eslint-plugin-custom-rules/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "eslint-plugin-custom-rules",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "author": "",
+  "license": "ISC"
+}

--- a/eslint-plugin-custom-rules/rules/no-text-size-class.js
+++ b/eslint-plugin-custom-rules/rules/no-text-size-class.js
@@ -1,0 +1,55 @@
+module.exports = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "disallow specific `text-` size classes, enforce `heading-*` and `body-*`",
+      category: "Stylistic Issues",
+      recommended: false,
+    },
+    fixable: null,
+    schema: [],
+  },
+  create: function (context) {
+    return {
+      JSXAttribute(node) {
+        if (node.name.name !== "className") {
+          return;
+        }
+
+        // Generates list of text-xs to text-xl, text-2xl to text-9xl
+        const disallowedTailwindTextSizeClasses = [
+          ...["xs", "sm", "md", "lg", "xl"],
+          ...Array.from({ length: 8 }, (_, i) => `${i + 2}xl`),
+        ].map((size) => `text-${size}`);
+
+        const containsDisallowedClass = (value) => {
+          return disallowedTailwindTextSizeClasses.some((disallowedClass) =>
+            value.includes(disallowedClass),
+          );
+        };
+
+        if (node.value.type === "Literal" || node.value.type === "JSXText") {
+          const value = node.value.value;
+          if (containsDisallowedClass(value)) {
+            context.report({
+              node,
+              message:
+                "Use `heading-*` or `body-*` classes instead of specific `text-` size classes.",
+            });
+          }
+        } else if (node.value.type === "TemplateLiteral") {
+          const quasis = node.value.quasis.map((q) => q.value.cooked);
+          const templateValue = quasis.join("");
+          if (containsDisallowedClass(templateValue)) {
+            context.report({
+              node,
+              message:
+                "Use `heading-*` or `body-*` classes instead of specific `text-` size classes in template literals.",
+            });
+          }
+        }
+      },
+    };
+  },
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "@types/react": "18.2.21",
         "@types/react-dom": "18.2.7",
         "autoprefixer": "10.4.15",
-        "eslint": "8.48.0",
         "eslint-config-next": "13.4.19",
         "framer-motion": "^10.16.4",
         "lodash": "^4.17.21",
@@ -39,7 +38,9 @@
       "devDependencies": {
         "@types/mapbox-gl": "^2.7.17",
         "@types/pbf": "^3.0.2",
-        "@types/pg": "^8.10.2"
+        "@types/pg": "^8.10.2",
+        "@typescript-eslint/parser": "^7.1.1",
+        "eslint": "^8.57.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -302,9 +303,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.48.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.48.0.tgz",
-      "integrity": "sha512-ZSjtmelB7IJfWD2Fvb7+Z+ChTIKWq6kjda95fLcQKNS5aheVHn4IkfgRQE3sIIzTcSLwLcLZUD9UBt+V7+h+Pw==",
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.0.tgz",
+      "integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
@@ -1091,14 +1092,6 @@
       "version": "14.1.0",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-14.1.0.tgz",
       "integrity": "sha512-Py8zIo+02ht82brwwhTg36iogzFqGLPXlRGKQw5s+qP/kMNc4MAyDeEwBKDijk6zTIbegEgu8Qy7C1LboslQAw=="
-    },
-    "node_modules/@next/eslint-plugin-next": {
-      "version": "13.4.19",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-13.4.19.tgz",
-      "integrity": "sha512-N/O+zGb6wZQdwu6atMZHbR7T9Np5SUFUjZqCbj0sXm+MwQO35M8TazVB4otm87GkXYs2l6OPwARd3/PUWhZBVQ==",
-      "dependencies": {
-        "glob": "7.1.7"
-      }
     },
     "node_modules/@next/swc-darwin-arm64": {
       "version": "14.1.0",
@@ -3759,14 +3752,15 @@
       "integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A=="
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "6.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.19.0.tgz",
-      "integrity": "sha512-1DyBLG5SH7PYCd00QlroiW60YJ4rWMuUGa/JBV0iZuqi4l4IK3twKPq5ZkEebmGqRjXWVgsUzfd3+nZveewgow==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.1.1.tgz",
+      "integrity": "sha512-ZWUFyL0z04R1nAEgr9e79YtV5LbafdOtN7yapNbn1ansMyaegl2D4bL7vHoJ4HPSc4CaLwuCVas8CVuneKzplQ==",
+      "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "6.19.0",
-        "@typescript-eslint/types": "6.19.0",
-        "@typescript-eslint/typescript-estree": "6.19.0",
-        "@typescript-eslint/visitor-keys": "6.19.0",
+        "@typescript-eslint/scope-manager": "7.1.1",
+        "@typescript-eslint/types": "7.1.1",
+        "@typescript-eslint/typescript-estree": "7.1.1",
+        "@typescript-eslint/visitor-keys": "7.1.1",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -3777,7 +3771,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0"
+        "eslint": "^8.56.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -3786,12 +3780,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "6.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.19.0.tgz",
-      "integrity": "sha512-dO1XMhV2ehBI6QN8Ufi7I10wmUovmLU0Oru3n5LVlM2JuzB4M+dVphCPLkVpKvGij2j/pHBWuJ9piuXx+BhzxQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.1.1.tgz",
+      "integrity": "sha512-cirZpA8bJMRb4WZ+rO6+mnOJrGFDd38WoXCEI57+CYBqta8Yc8aJym2i7vyqLL1vVYljgw0X27axkUXz32T8TA==",
+      "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.19.0",
-        "@typescript-eslint/visitor-keys": "6.19.0"
+        "@typescript-eslint/types": "7.1.1",
+        "@typescript-eslint/visitor-keys": "7.1.1"
       },
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -3802,9 +3797,10 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "6.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.19.0.tgz",
-      "integrity": "sha512-lFviGV/vYhOy3m8BJ/nAKoAyNhInTdXpftonhWle66XHAtT1ouBlkjL496b5H5hb8dWXHwtypTqgtb/DEa+j5A==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.1.1.tgz",
+      "integrity": "sha512-KhewzrlRMrgeKm1U9bh2z5aoL4s7K3tK5DwHDn8MHv0yQfWFz/0ZR6trrIHHa5CsF83j/GgHqzdbzCXJ3crx0Q==",
+      "dev": true,
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
       },
@@ -3814,12 +3810,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "6.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.19.0.tgz",
-      "integrity": "sha512-o/zefXIbbLBZ8YJ51NlkSAt2BamrK6XOmuxSR3hynMIzzyMY33KuJ9vuMdFSXW+H0tVvdF9qBPTHA91HDb4BIQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.1.1.tgz",
+      "integrity": "sha512-9ZOncVSfr+sMXVxxca2OJOPagRwT0u/UHikM2Rd6L/aB+kL/QAuTnsv6MeXtjzCJYb8PzrXarypSGIPx3Jemxw==",
+      "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.19.0",
-        "@typescript-eslint/visitor-keys": "6.19.0",
+        "@typescript-eslint/types": "7.1.1",
+        "@typescript-eslint/visitor-keys": "7.1.1",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -3844,6 +3841,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -3852,6 +3850,7 @@
       "version": "9.0.3",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
       "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -3863,11 +3862,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "6.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.19.0.tgz",
-      "integrity": "sha512-hZaUCORLgubBvtGpp1JEFEazcuEdfxta9j4iUwdSAr7mEsYYAp3EAUyCZk3VEEqGj6W+AV4uWyrDGtrlawAsgQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.1.1.tgz",
+      "integrity": "sha512-yTdHDQxY7cSoCcAtiBzVzxleJhkGB9NncSIyMYe2+OGON1ZsP9zOPws/Pqgopa65jvknOjlk/w7ulPlZ78PiLQ==",
+      "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.19.0",
+        "@typescript-eslint/types": "7.1.1",
         "eslint-visitor-keys": "^3.4.1"
       },
       "engines": {
@@ -3877,6 +3877,11 @@
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       }
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
+      "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ=="
     },
     "node_modules/acorn": {
       "version": "8.11.3",
@@ -4961,17 +4966,18 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.48.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.48.0.tgz",
-      "integrity": "sha512-sb6DLeIuRXxeM1YljSe1KEx9/YYeZFQWcV8Rq9HfigmdDEugjLEVEa1ozDjL6YDjBpQHPJxJzze+alxi4T3OLg==",
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
+      "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
-        "@eslint/eslintrc": "^2.1.2",
-        "@eslint/js": "8.48.0",
-        "@humanwhocodes/config-array": "^0.11.10",
+        "@eslint/eslintrc": "^2.1.4",
+        "@eslint/js": "8.57.0",
+        "@humanwhocodes/config-array": "^0.11.14",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
+        "@ungap/structured-clone": "^1.2.0",
         "ajv": "^6.12.4",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
@@ -5036,6 +5042,134 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-config-next/node_modules/@next/eslint-plugin-next": {
+      "version": "13.4.19",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-13.4.19.tgz",
+      "integrity": "sha512-N/O+zGb6wZQdwu6atMZHbR7T9Np5SUFUjZqCbj0sXm+MwQO35M8TazVB4otm87GkXYs2l6OPwARd3/PUWhZBVQ==",
+      "dependencies": {
+        "glob": "7.1.7"
+      }
+    },
+    "node_modules/eslint-config-next/node_modules/@typescript-eslint/parser": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
+      "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "6.21.0",
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/typescript-estree": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-config-next/node_modules/@typescript-eslint/scope-manager": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
+      "integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-config-next/node_modules/@typescript-eslint/types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
+      "integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-config-next/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
+      "integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "minimatch": "9.0.3",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-config-next/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
+      "integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-config-next/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/eslint-config-next/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/eslint-import-resolver-node": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "@types/react": "18.2.21",
     "@types/react-dom": "18.2.7",
     "autoprefixer": "10.4.15",
-    "eslint": "8.48.0",
     "eslint-config-next": "13.4.19",
     "framer-motion": "^10.16.4",
     "lodash": "^4.17.21",
@@ -41,6 +40,8 @@
   "devDependencies": {
     "@types/mapbox-gl": "^2.7.17",
     "@types/pbf": "^3.0.2",
-    "@types/pg": "^8.10.2"
+    "@types/pg": "^8.10.2",
+    "@typescript-eslint/parser": "^7.1.1",
+    "eslint": "^8.57.0"
   }
 }

--- a/src/app/components/AboutPage.tsx
+++ b/src/app/components/AboutPage.tsx
@@ -14,12 +14,12 @@ export default function AboutPage() {
     <div className="flex flex-col min-h-screen">
       <div className="flex-grow grid grid-cols-1 md:grid-cols-2 gap-4 py-8 px-4 md:px-6 lg:px-24">
         <div className="container mx-auto px-4 md:px-8">
-          <h2 className="text-3xl font-semibold mb-4">What is this?</h2>
-          <p className="text-lg mb-4">
+          <h2 className="heading-2xl font-semibold mb-4">What is this?</h2>
+          <p className="body-md mb-4">
             Philadelphia has a gun violence problem. Clean & Green Philly
             empowers Philadelphians to take action to solve it.
           </p>
-          <p className="text-lg">
+          <p className="body-md">
             Our dashboard helps local residents, non-profit organizations, and
             government stakeholders identify and prioritize vacant properties
             for interventions, understand how to transform the properties
@@ -27,8 +27,8 @@ export default function AboutPage() {
             do so.
           </p>
           <br></br>
-          <h2 className="text-3xl font-semibold mb-4">Why make this?</h2>
-          <p className="text-lg mb-4">
+          <h2 className="heading-2xl font-semibold mb-4">Why make this?</h2>
+          <p className="body-md mb-4">
             Clean & Green Philly was built to respond to Philadelphia’s historic
             gun violence problem. With homicides trending up since 2013, and a
             record high of 562 gun deaths in 2021, community members need
@@ -41,7 +41,7 @@ export default function AboutPage() {
               height={500}
             />
           </div>
-          <p className="text-lg mb-4">
+          <p className="body-md mb-4">
             Many solutions focus on long-term impact, including{" "}
             <a
               href="https://controller.phila.gov/philadelphia-audits/fy23-anti-violence-budget/#/"
@@ -57,7 +57,7 @@ export default function AboutPage() {
             everyday Philadelphians to take action to reduce gun violence in our
             city.
           </p>
-          <p className="text-lg mb-4">
+          <p className="body-md mb-4">
             Research shows that greening and cleaning vacant properties is one
             of the most impactful, cost-effective interventions available to
             reduce gun violence in a neighborhood. For example, Dr. Eugenia
@@ -109,7 +109,7 @@ export default function AboutPage() {
               </ModalContent>
             </Modal>
           </div>
-          <p className="text-lg">
+          <p className="body-md">
             Transforming Philadelphia’s vacant lots should be a key strategy to
             combating gun violence here. But in a city with nearly 40,000 vacant
             properties, the main obstacle is figuring out which properties to
@@ -128,20 +128,22 @@ export default function AboutPage() {
           </div>
         </div>
         <div className="container mx-auto px-4 md:px-8">
-          <h2 className="text-3xl font-semibold mb-4">How was this built?</h2>
-          <p className="text-lg mb-4">
+          <h2 className="heading-2xl font-semibold mb-4">
+            How was this built?
+          </h2>
+          <p className="body-md mb-4">
             Clean & Green Philly combines several public datasets in order to
             categorize Philadelphia’s vacant properties based on how important
             it is that someone intervene there and what the easiest way to do
             that is.
           </p>
-          <p className="text-lg mb-4">
+          <p className="body-md mb-4">
             We created the dataset based on the original research conducted by
             Dr. Eugenia South and her colleagues, as well as many conversations
             with stakeholders, including community residents, CDCs, City
             government offices, academic researchers, and more.
           </p>
-          <p className="text-lg">
+          <p className="body-md">
             All of the code used to build this tool is{" "}
             <a
               href="https://github.com/CodeForPhilly/vacant-lots-proj"
@@ -153,17 +155,14 @@ export default function AboutPage() {
             </a>
             . We hope to add data documentation in the near future. For further
             questions about our methods, feel free to reach out to us at{" "}
-            <a
-              href="mailto:cleanandgreenphl@gmail.com"
-              className="link"
-            >
+            <a href="mailto:cleanandgreenphl@gmail.com" className="link">
               cleangreenphilly@gmail.com
             </a>
             .
           </p>
           <br></br>
-          <h2 className="text-3xl font-semibold mb-4">Who built this?</h2>
-          <p className="text-lg mb-4">
+          <h2 className="heading-2xl font-semibold mb-4">Who built this?</h2>
+          <p className="body-md mb-4">
             Clean & Green Philly was built by a team of Code for Philly
             volunteers. The project was created and led by{" "}
             <a
@@ -205,32 +204,31 @@ export default function AboutPage() {
             led the UX team. Thanks, too, to the many other contributors along
             the way.
           </p>
-          <p className="text-lg mb-4">
+          <p className="body-md mb-4">
             Our efforts have been informed and advanced by local residents,
             community leaders, City staff, faculty at the University of
             Pennsylvania, Temple University, and Thomas Jefferson University;
             and many others. Special thanks are due to the Code for Philly
             leadership, Jon Geeting, Dante Leonard, Mjumbe Poe, and Vicky Tam.
           </p>
-          <p className="text-lg">
+          <p className="body-md">
             Lastly, we are grateful to Dr. Eugenia South and her colleagues,
             whose work this project depends on.
           </p>
           <br></br>
-          <h2 className="text-3xl font-semibold mb-4">Feedback</h2>
-          <p className="text-lg mb-4">
+          <h2 className="heading-2xl font-semibold mb-4">Feedback</h2>
+          <p className="body-md mb-4">
             If you find issues in this website or would like to offer us
             feedback, please reach out to us at{" "}
-            <a
-              href="mailto:cleanandgreenphl@gmail.com"
-              className="link"
-            >
+            <a href="mailto:cleanandgreenphl@gmail.com" className="link">
               cleanandgreenphl@gmail.com
             </a>
             .
           </p>
-          <h2 className="text-3xl font-semibold mb-4">Removing Properties</h2>
-          <p className="text-lg mb-4">
+          <h2 className="heading-2xl font-semibold mb-4">
+            Removing Properties
+          </h2>
+          <p className="body-md mb-4">
             If you would like to request that we remove a property from the
             dashboard, please see our{" "}
             <a href="/request-removal" className="link">

--- a/src/app/components/FilterView.tsx
+++ b/src/app/components/FilterView.tsx
@@ -57,7 +57,7 @@ const FilterView: FC<FilterViewProps> = ({ setCurrentView }) => {
   return (
     <div className="p-6">
       <div className="flex justify-between items-center">
-        <h1 className="font-semibold text-xl">Filter</h1>
+        <h1 className="font-semibold heading-xl">Filter</h1>
         <Button
           size="sm"
           className="bg-green-60 text-white"

--- a/src/app/components/Filters/DimensionFilter.tsx
+++ b/src/app/components/Filters/DimensionFilter.tsx
@@ -18,7 +18,7 @@ const DimensionFilter: FC<DimensionFilterProps> = ({
 }) => {
   const { dispatch, appFilter } = useFilter();
   const [selectedKeys, setSelectedKeys] = useState<string[]>(
-    appFilter[property]?.values || []
+    appFilter[property]?.values || [],
   );
 
   const toggleDimension = (dimension: string) => {
@@ -36,10 +36,14 @@ const DimensionFilter: FC<DimensionFilterProps> = ({
   return (
     <div className="pb-6">
       <div className="flex items-center mb-2">
-        <div className="text-md flex items-center">
-          <h2>{display}</h2>
+        <div className="flex items-center">
+          <h2 className="heading-lg">{display}</h2>
           <Tooltip content={tooltip} placement="top" showArrow color="primary">
-            <Info alt="More Info" className="h-5 w-9 text-gray-500 pl-2 pr-2 cursor-pointer" tabIndex={0} />
+            <Info
+              alt="More Info"
+              className="h-5 w-9 text-gray-500 pl-2 pr-2 cursor-pointer"
+              tabIndex={0}
+            />
           </Tooltip>
         </div>
       </div>
@@ -51,10 +55,14 @@ const DimensionFilter: FC<DimensionFilterProps> = ({
             onPress={() => toggleDimension(option)}
             size="sm"
             color={selectedKeys.includes(option) ? "success" : "default"}
-            className="mb-2 p-2 h-6"
+            className="mb-2 p-2 h-6 body-sm"
             radius="full"
             aria-pressed={selectedKeys.includes(option)}
-            startContent={selectedKeys.includes(option) ? <Check className="h-3 w-3" /> : undefined}
+            startContent={
+              selectedKeys.includes(option) ? (
+                <Check className="h-3 w-3" />
+              ) : undefined
+            }
           >
             {option}
           </Button>

--- a/src/app/components/Footer.tsx
+++ b/src/app/components/Footer.tsx
@@ -4,12 +4,12 @@ const Footer = () => (
       <nav className="w-full" aria-label="content info">
         <ul className="flex justify-between items-center w-full backdrop-saturate-150 bg-background/70">
           <li>
-            <span className="text-sm text-gray-600">
+            <span className="base-sm text-gray-600">
               © 2024 Clean & Green Philly
             </span>
           </li>
 
-          <li className="text-sm underline text-gray-600 mx-auto">
+          <li className="base-sm underline text-gray-600 mx-auto">
             <a href="/legal-disclaimer" className="hover:text-gray-800">
               Legal Disclaimer
             </a>
@@ -18,7 +18,7 @@ const Footer = () => (
           <li>
             <a
               href="mailto:cleanandgreenphl@gmail.com"
-              className="text-sm underline text-gray-600 hover:text-gray-800"
+              className="base-sm underline text-gray-600 hover:text-gray-800"
             >
               Contact Us
             </a>

--- a/src/app/components/GetAccessPage.tsx
+++ b/src/app/components/GetAccessPage.tsx
@@ -4,12 +4,12 @@ export default function GetAccessPage() {
   return (
     <div className="flex flex-col min-h-screen">
       <div className="flew-grow container mx-auto pt-20">
-        <h1 className="text-4xl font-bold mb-6">Get Access</h1>
+        <h1 className="heading-3xl font-bold mb-6">Get Access</h1>
 
-        <h2 className="text-2xl font-bold mt-8">
+        <h2 className="heading-2xl font-bold mt-8">
           What does "get access" mean?
         </h2>
-        <p>
+        <p className="body-md">
           In order to intervene in a property, you need to have some kind of
           legal access to do so. Broadly, this means either becoming the owner
           of the property yourself or reaching a legal agreement with the owner
@@ -19,10 +19,10 @@ export default function GetAccessPage() {
           these options are and how you can get help with each.
         </p>
 
-        <h2 className="text-2xl font-bold mt-8">
+        <h2 className="heading-2xl font-bold mt-8">
           How can I get access to a specific property?
         </h2>
-        <p>
+        <p className="body-md">
           Generally speaking, there are two ways to get access to a property:
           you can either become the owner yourself or reach an agreement with
           the owner to let you access the property. Clean & Green Philly
@@ -158,10 +158,10 @@ export default function GetAccessPage() {
           </AccordionItem>
         </Accordion>
 
-        <h2 className="text-2xl font-bold mt-8">
+        <h2 className="heading-2xl font-bold mt-8">
           What do you mean by "do nothing"?
         </h2>
-        <p>
+        <p className="body-md">
           Although most properties have at least one reasonable way to get
           access to them, in some cases, a property may have a particular
           combination of factors that make it difficult to impossible to get
@@ -174,8 +174,8 @@ export default function GetAccessPage() {
           easily pursue an intervention.
         </p>
 
-        <h2 className="text-2xl font-bold mt-8">Are there other options?</h2>
-        <p>
+        <h2 className="heading-2xl font-bold mt-8">Are there other options?</h2>
+        <p className="body-md">
           The four options mentioned above are not a complete list of ways to
           get access to a vacant property in Philadelphia. There are several
           others worth considering. However, the criteria for these options

--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -53,16 +53,12 @@ const Header = () => (
             className="flex items-center hover:text-blue-500 hover:underline bg-white"
           >
             <Hand className="h-6 w-6" aria-hidden="true" />
-            Take Action
+            <span className="body-md">Take Action</span>
           </Button>
         </DropdownTrigger>
         <DropdownMenu aria-label="Take Action">
-          <DropdownItem href="/take-action-overview">
-            Overview
-          </DropdownItem>
-          <DropdownItem href="/get-access">
-            Get Access
-          </DropdownItem>
+          <DropdownItem href="/take-action-overview">Overview</DropdownItem>
+          <DropdownItem href="/get-access">Get Access</DropdownItem>
           <DropdownItem href="/transform-property">
             Transform a Property
           </DropdownItem>
@@ -77,16 +73,12 @@ const Header = () => (
             className="flex items-center hover:text-blue-500 hover:underline bg-white"
           >
             <Info className="h-6 w-6" aria-hidden="true" />
-            About
+            <span className="body-md">About</span>
           </Button>
         </DropdownTrigger>
         <DropdownMenu aria-label="Overview">
-          <DropdownItem href="/about">
-            Overview
-          </DropdownItem>
-          <DropdownItem href="/methodology">
-            Methodology
-          </DropdownItem>
+          <DropdownItem href="/about">Overview</DropdownItem>
+          <DropdownItem href="/methodology">Methodology</DropdownItem>
         </DropdownMenu>
       </Dropdown>
     </NavbarContent>

--- a/src/app/components/IconLink.tsx
+++ b/src/app/components/IconLink.tsx
@@ -14,7 +14,7 @@ const IconLink: FC<IconLinkProps> = ({ icon, text, href }) => (
       className="flex items-center hover:text-blue-500 hover:underline bg-white"
       startContent={<div className="w-5">{icon}</div>}
     >
-      {text}
+      <span className="body-md">{text}</span>
     </Button>
   </Link>
 );

--- a/src/app/components/LandingPage.tsx
+++ b/src/app/components/LandingPage.tsx
@@ -20,7 +20,7 @@ const LandingPage = () => (
   <div className="container mx-auto px-4">
     <div className="flex flex-col md:flex-row justify-between items-start md:items-center my-10">
       <div className="text-left pr-10">
-        <h1 className="text-green-600 text-xl md:text-2xl lg:text-5xl font-thin leading-tight md:leading-[3rem]">
+        <h1 className="text-green-600 heading-3xl font-thin leading-tight md:leading-[3rem]">
           <span className="block">
             Cleaning and greening vacant properties can{" "}
             <span className="font-extrabold">reduce gun violence</span> in
@@ -31,15 +31,20 @@ const LandingPage = () => (
       <div className="flex flex-col justify-between items-end">
         <div className="text-gray-700 mb-4">
           {/* Responsive paragraphs */}
-          <p className="hidden md:block">
+          <p className="hidden md:block body-lg">
             This tool can empower you to find the highest-impact properties in
             Philadelphia and take action.
           </p>
         </div>
         <div className="inline-flex space-x-2">
-          <Button href="/map" as={Link} size="lg" className="bg-green-600 text-white">
+          <Button
+            href="/map"
+            as={Link}
+            size="lg"
+            className="bg-green-600 text-white"
+          >
             <ArrowRightIcon className="w-5 h-5 mr-2" />
-            Find properties
+            <span className="body-md">Find properties</span>
           </Button>
           <Button
             href="about"

--- a/src/app/components/MethodologyPage.tsx
+++ b/src/app/components/MethodologyPage.tsx
@@ -5,11 +5,11 @@ export default function AboutPage() {
     <div className="flex flex-col min-h-screen">
       <div className="flex-grow grid grid-cols-1 md:grid-cols-2 gap-4 py-8 px-4 md:px-6 lg:px-24">
         <div className="container mx-auto px-4 md:px-8">
-          <h1 className="text-4xl font-bold mb-6">Methodology</h1>
+          <h1 className="heading-3xl font-bold mb-6">Methodology</h1>
 
-          <h2 className="text-3xl font-semibold mb-4">Overview</h2>
+          <h2 className="heading-2xl font-semibold mb-4">Overview</h2>
 
-          <p className="text-lg mb-4">
+          <p className="body-md mb-4">
             Clean & Green Philly combines several public datasets in order to
             categorize Philadelphia’s vacant properties based on how important
             it is that someone intervene there and what the easiest way to do
@@ -28,15 +28,12 @@ export default function AboutPage() {
             researchers, and more.
           </p>
 
-          <p className="text-lg">
+          <p className="body-md">
             Although we aim to simplify the decision-making process for users of
             Clean & Green Philly, we value transparency. Below, we lay out key
             aspects of our methodology. For further questions, feel free to
             reach out to us at{" "}
-            <a
-              href="mailto:cleanandgreenphl@gmail.com"
-              className="link"
-            >
+            <a href="mailto:cleanandgreenphl@gmail.com" className="link">
               cleangreenphilly@gmail.com
             </a>
             .
@@ -44,11 +41,11 @@ export default function AboutPage() {
 
           <br></br>
 
-          <h2 className="text-3xl font-semibold mb-4">
+          <h2 className="heading-2xl font-semibold mb-4">
             How did you determine "possible impact"?
           </h2>
 
-          <p className="text-lg mb-4">
+          <p className="body-md mb-4">
             Clean & Green Philly aims to reduce gun violence by cleaning and
             greening vacant properties. Accordingly, we base our calculation of
             possible impact on which properties 1) have high levels of gun
@@ -67,7 +64,7 @@ export default function AboutPage() {
             and the basis for Dr. South’s research.
           </p>
 
-          <p className="text-lg mb-4">
+          <p className="body-md mb-4">
             Concretely, we combine Philadelphia Police Department data on gun
             violence with L&I data on various kinds of unclean or hazardous
             conditions (e.g., illegal dumping or abandoned cars),{" "}
@@ -88,11 +85,11 @@ export default function AboutPage() {
 
           <br></br>
 
-          <h2 className="text-3xl font-semibold mb-4">
+          <h2 className="heading-2xl font-semibold mb-4">
             How did you determine "access process"?
           </h2>
 
-          <p className="text-lg mb-4">
+          <p className="body-md mb-4">
             Getting legal access to intervene in a property is a significant
             obstacle to cleaning and greening vacant properties. We hope to
             reduce this barrier by helping users identify the most properties
@@ -123,7 +120,7 @@ export default function AboutPage() {
             .
           </p>
 
-          <p className="text-lg mb-4">
+          <p className="body-md mb-4">
             Additionally, we note that our access process labels are only
             suggestions. Anyone using Clean & Green Philly should verify the
             information we have provided before acting on it. When applicable,
@@ -137,11 +134,11 @@ export default function AboutPage() {
         </div>
 
         <div className="container mx-auto px-4 md:px-8">
-          <h2 className="text-3xl font-semibold mb-4">
+          <h2 className="heading-2xl font-semibold mb-4">
             Gun Crime Calculations
           </h2>
 
-          <p className="text-lg mb-4">
+          <p className="body-md mb-4">
             It is impossible to reduce the impact of a shooting to a single
             statistic, and Clean & Green Philly applauds the organizations
             throughout our city who work to give voice to the profound effect of
@@ -168,11 +165,11 @@ export default function AboutPage() {
 
           <br></br>
 
-          <h2 className="text-3xl font-semibold mb-4">
+          <h2 className="heading-2xl font-semibold mb-4">
             Protecting Community Gardens
           </h2>
 
-          <p className="text-lg mb-4">
+          <p className="body-md mb-4">
             To protect community gardens from potential predatory development,
             we have excluded all properties listed by the Pennsylvania
             Horticultural Society and Neighborhoods Garden Trust as community
@@ -187,9 +184,9 @@ export default function AboutPage() {
 
           <br></br>
 
-          <h2 className="text-3xl font-semibold mb-4">Our Code</h2>
+          <h2 className="heading-2xl font-semibold mb-4">Our Code</h2>
 
-          <p className="text-lg mb-4">
+          <p className="body-md mb-4">
             Clean & Green Philly was created by a Code for Philly team. In
             keeping with the open source ethos of Code for Philly, all of the
             code used to build this tool is available on{" "}
@@ -207,9 +204,9 @@ export default function AboutPage() {
 
           <br></br>
 
-          <h2 className="text-3xl font-semibold mb-4">Data Sources</h2>
+          <h2 className="heading-2xl font-semibold mb-4">Data Sources</h2>
 
-          <p className="text-lg mb-4">
+          <p className="body-md mb-4">
             Documentation of the data that we use is available on{" "}
             <a
               href="https://github.com/CodeForPhilly/vacant-lots-proj/blob/main/DATASETS.md"

--- a/src/app/components/PropertyCard.tsx
+++ b/src/app/components/PropertyCard.tsx
@@ -57,8 +57,8 @@ const PropertyCard = ({ feature, setSelectedProperty }: PropertyCardProps) => {
             />
           </div>
           <div className="p-2">
-            <div className="font-bold text-lg">{formattedAddress}</div>
-            <div className="text-gray-700 mb">
+            <div className="font-bold heading-lg">{formattedAddress}</div>
+            <div className="text-gray-700 body-sm">
               {guncrime_density} Gun Crime Rate
             </div>
           </div>
@@ -66,7 +66,7 @@ const PropertyCard = ({ feature, setSelectedProperty }: PropertyCardProps) => {
             <Chip
               classNames={{
                 base: `${priorityClass} border-small border-white/50`,
-                content: "text-white mb",
+                content: "text-white body-sm",
               }}
             >
               {priority_level + " Priority"}

--- a/src/app/components/PropertyDetailSection.tsx
+++ b/src/app/components/PropertyDetailSection.tsx
@@ -92,8 +92,8 @@ const PropertyDetailSection: FC<PropertyDetailSectionProps> = ({
                     setSelectedProperty(
                       items.find(
                         (item) =>
-                          properties?.OPA_ID === item?.properties?.OPA_ID
-                      ) || null
+                          properties?.OPA_ID === item?.properties?.OPA_ID,
+                      ) || null,
                     );
                   }}
                 >
@@ -129,7 +129,7 @@ const PropertyDetailSection: FC<PropertyDetailSectionProps> = ({
               />
             </div>
             <div className="flex w-full justify-center p-2">
-              <p className="text-sm text-gray-500">
+              <p className="body-sm text-gray-500">
                 Note: only the first 100 properties can be viewed in list.
                 Filter or zoom in to a smaller area to see more detail.{" "}
               </p>

--- a/src/app/components/PropertyMap.tsx
+++ b/src/app/components/PropertyMap.tsx
@@ -112,7 +112,7 @@ const PropertyMap: FC<PropertyMapProps> = ({
 
         return acc;
       },
-      [] as any[]
+      [] as any[],
     );
 
     map.setFilter("vacant_properties_tiles", ["all", ...mapFilter]);
@@ -235,7 +235,7 @@ const PropertyMap: FC<PropertyMapProps> = ({
         layers: ["vacant_properties_tiles"],
       });
       const mapItem = features.find(
-        (feature) => feature.properties?.OPA_ID === id
+        (feature) => feature.properties?.OPA_ID === id,
       );
 
       if (mapItem != null) {
@@ -244,7 +244,7 @@ const PropertyMap: FC<PropertyMapProps> = ({
         if (coordinates.length > 0) {
           // Filter out coordinates that are not available
           const validCoordinates = coordinates.filter(
-            ([x, y]) => !isNaN(x) && !isNaN(y)
+            ([x, y]) => !isNaN(x) && !isNaN(y),
           );
 
           if (validCoordinates.length > 0) {
@@ -253,7 +253,7 @@ const PropertyMap: FC<PropertyMapProps> = ({
                 prevSum[0] + position[0],
                 prevSum[1] + position[1],
               ],
-              [0, 0]
+              [0, 0],
             );
 
             let finalPoint = [
@@ -329,7 +329,7 @@ const PropertyMap: FC<PropertyMapProps> = ({
             onClose={() => setPopupInfo(null)}
           >
             <div>
-              <p className="font-semibold text-md p-1">
+              <p className="font-semibold body-md p-1">
                 {popupInfo.feature.address}
               </p>
             </div>

--- a/src/app/components/SidePanelControlBar.tsx
+++ b/src/app/components/SidePanelControlBar.tsx
@@ -30,7 +30,7 @@ const SearchBarComponent: FC<SidePanelControlBarProps> = ({
     <div className="flex justify-between items-center bg-white p-2 h-12">
       {/* Left-aligned content: Total Properties in View */}
       <div className="px-4 py-2">
-        <h1 className="text-md">
+        <h1 className="body-md">
           <span className="font-bold">{featureCount}</span> Properties in View
         </h1>
       </div>
@@ -42,7 +42,7 @@ const SearchBarComponent: FC<SidePanelControlBarProps> = ({
           startContent={<Funnel className="h-6 w-6" />}
           className="bg-white"
         >
-          Filter
+          <span className="body-md">Filter</span>
         </Button>
 
         <Tooltip content="View" showArrow color="primary">

--- a/src/app/components/SinglePropertyDetail.tsx
+++ b/src/app/components/SinglePropertyDetail.tsx
@@ -70,7 +70,8 @@ const SinglePropertyDetail = ({
           }}
           onClick={() => setSelectedProperty(null)}
         >
-          <ArrowLeft color="#3D3D3D" size={24} /> Back{" "}
+          <ArrowLeft color="#3D3D3D" size={24} />{" "}
+          <span className="body-md">Back</span>{" "}
         </Button>
       </div>
       <div className="bg-white rounded-lg overflow-hidden">
@@ -87,7 +88,7 @@ const SinglePropertyDetail = ({
       <div className="py-4 px-2">
         <div className="flex justify-between content-center">
           <h2
-            className="font-bold text-2xl"
+            className="font-bold heading-2xl"
             style={{
               textTransform: "capitalize",
             }}
@@ -100,7 +101,7 @@ const SinglePropertyDetail = ({
               target="_blank"
               rel="noopener noreferrer"
               color="primary"
-              className="flex p-2 items-center gap-1"
+              className="flex p-2 items-center gap-1 body-md"
             >
               Atlas Link
               <ArrowSquareOut className="inline h-6 w-6" aria-hidden="true" />
@@ -207,7 +208,7 @@ const SinglePropertyDetail = ({
         </tbody>
       </table>
 
-      <h3 className="font-bold mb-2 py-2 text-xl">Getting Access</h3>
+      <h3 className="font-bold mb-2 py-2 heading-xl">Getting Access</h3>
       <p className="mb-4">
         Based on the information about this property, we believe that you can
         get access to this property through:
@@ -258,7 +259,9 @@ const SinglePropertyDetail = ({
         </a>
       </p>
 
-      <h3 className="font-bold mb-2 py-2 text-xl">Ways to transform the lot</h3>
+      <h3 className="font-bold mb-2 py-2 heading-xl">
+        Ways to transform the lot
+      </h3>
       <p className="mb-4">
         To see different ways in which you might transform this property, see
         <a
@@ -288,7 +291,7 @@ const SinglePropertyDetail = ({
       </div>
       */}
 
-      <h3 className="font-bold mb-2 py-2 text-xl">Remove This Property</h3>
+      <h3 className="font-bold mb-2 py-2 heading-xl">Remove This Property</h3>
       <p>
         If you would like to request that we remove this property from the
         dashboard, please see our{" "}

--- a/src/app/components/SinglePropertyInfoCard.tsx
+++ b/src/app/components/SinglePropertyInfoCard.tsx
@@ -16,7 +16,7 @@ const SinglePropertyInfoCard: FC<SinglePropertyInfoCardProps> = ({
       <div className="flex gap-4 items-center">
         <div>{icon}</div>
         <div>
-          <h4 className="font-bold mb-2 text-xl">{title}</h4>
+          <h4 className="font-bold mb-2 heading-lg">{title}</h4>
           <p>{body}</p>
         </div>
       </div>

--- a/src/app/components/TakeActionOverviewPage.tsx
+++ b/src/app/components/TakeActionOverviewPage.tsx
@@ -2,9 +2,9 @@ export default function TakeActionOverviewPage() {
   return (
     <div className="flex flex-col min-h-screen">
       <div className="flex-grow container mx-auto pt-20">
-        <h1 className="text-4xl font-bold mb-6">Overview</h1>
+        <h1 className="heading-3xl font-bold mb-6">Overview</h1>
 
-        <p>
+        <p className="body-md">
           Clean & Green Philly can help you prioritize vacant properties to
           return to productive use. We encourage cleaning and greening
           interventions, but also recognize that there is no one-size-fits-all
@@ -16,14 +16,16 @@ export default function TakeActionOverviewPage() {
           cleaning and greening or otherwise.
         </p>
 
-        <h2 className="text-2xl font-bold mt-8">What can I do?</h2>
-        <p>
+        <h2 className="heading-2xl font-bold mt-8">What can I do?</h2>
+        <p className="body-md">
           Using this site, you can identify a high impact property, figure out
           how to get legal access to it, and decide on your preferred
           intervention to return the lot to productive use.
         </p>
 
-        <p>At a minimum, we encourage cleaning and greening. This involves:</p>
+        <p className="body-md">
+          At a minimum, we encourage cleaning and greening. This involves:
+        </p>
         <ul className="list-disc pl-6 mb-4">
           <li>Removing trash and debris</li>
           <li>Grading the land</li>
@@ -32,18 +34,18 @@ export default function TakeActionOverviewPage() {
           <li>Regular maintenance</li>
         </ul>
 
-        <p>
+        <p className="body-md">
           The cost for these kinds of projects is usually low, about $5 per
           square yard, with maintenance around $0.50 per square yard. Even if
           you can't do everything, small steps like putting up a fence, planting
           some trees, or just keeping the area clean can make a big difference.
         </p>
 
-        <h2 className="text-2xl font-bold mt-8">
+        <h2 className="heading-2xl font-bold mt-8">
           How can Clean & Green Philly help me take action?
         </h2>
 
-        <p>Basic use of Clean & Green Philly is simple:</p>
+        <p className="body-md">Basic use of Clean & Green Philly is simple:</p>
         <ol className="list-decimal pl-6 mb-4">
           <li>
             Use the map to identify properties where you can have the highest
@@ -61,7 +63,7 @@ export default function TakeActionOverviewPage() {
           <li>Take action!</li>
         </ol>
 
-        <p>
+        <p className="body-md">
           In the future, we hope to add more specific information on things like
           applying for small grants, navigating the legal system, and more.
         </p>

--- a/src/app/components/TransformPropertyPage.tsx
+++ b/src/app/components/TransformPropertyPage.tsx
@@ -4,9 +4,9 @@ export default function TransformPropertyPage() {
   return (
     <div className="flex flex-col min-h-screen">
       <div className="flew-grow container mx-auto pt-20">
-        <h1 className="text-4xl font-bold mb-6">Transform a Property</h1>
+        <h1 className="heading-3xl font-bold mb-6">Transform a Property</h1>
 
-        <p>
+        <p className="body-md">
           Clean & Green Philly aims to help reduce gun violence by intervening
           in vacant properties. Very simply, this means improving the property.
           This can range from removing trash to planting a community garden,
@@ -15,8 +15,8 @@ export default function TransformPropertyPage() {
           impacts the neighborhood around it.
         </p>
 
-        <h2 className="text-2xl font-bold mt-8">Types of Interventions</h2>
-        <p>
+        <h2 className="heading-2xl font-bold mt-8">Types of Interventions</h2>
+        <p className="body-md">
           The original research that Clean & Green Philly is based on promotes
           “cleaning and greening”. This includes removing trash, grading the
           land, planting trees, installing low fences, and maintaining the
@@ -24,30 +24,32 @@ export default function TransformPropertyPage() {
           highly effective; even something as simple as cleaning up trash can
           have a big impact. That said, there are many ways to transform a
           vacant property. You could, for example:
-          <ul className="list-disc pl-6 mb-4">
-            <li>Partner with a local restaurant to offer outdoor eating</li>
-            <li>Install bike parking</li>
-            <li>
-              Work with the Philadelphia Water Department to install green
-              stormwater infrastructure
-            </li>
-            <li>
-              Plant a pollinator garden to attract birds, butterflies, and bees
-            </li>
-            <li>
-              Connect with a non-profit organization to build affordable housing
-            </li>
-          </ul>
+        </p>
+        <ul className="list-disc pl-6 my-4">
+          <li>Partner with a local restaurant to offer outdoor eating</li>
+          <li>Install bike parking</li>
+          <li>
+            Work with the Philadelphia Water Department to install green
+            stormwater infrastructure
+          </li>
+          <li>
+            Plant a pollinator garden to attract birds, butterflies, and bees
+          </li>
+          <li>
+            Connect with a non-profit organization to build affordable housing
+          </li>
+        </ul>
+        <p className="body-md">
           These are just some of the many possibilities. Remember to be both
           creative and practical: there is no one-size-fits-all solution, and
           Philadelphia will need a variety of uses in its vacant properties,
           including green space, housing, parks, commercial space, and more.
         </p>
 
-        <h2 className="text-2xl font-bold mt-8">
+        <h2 className="heading-2xl font-bold mt-8">
           What's right for my property?
         </h2>
-        <p>
+        <p className="body-md">
           Different properties have different opportunities and different
           challenges. Some properties might be a great spot for a rain garden
           but not for a playground. Likewise, you wouldn’t want to start a
@@ -67,15 +69,15 @@ export default function TransformPropertyPage() {
           maintenance you’re willing or able to do.
         </p>
 
-        <h2 className="text-2xl font-bold mt-8">Where can I get help?</h2>
-        <p>
+        <h2 className="heading-2xl font-bold mt-8">Where can I get help?</h2>
+        <p className="body-md">
           Many organizations in Philadelphia offer support transforming vacant
           properties.
         </p>
-        <h3 className="text-xl font-bold mt-8 mb-4">
+        <h3 className="heading-xl font-bold mt-8 mb-4">
           Community Groups and Local Representatives
         </h3>
-        <p>
+        <p className="body-md">
           For help with greening projects, reach out to local Neighborhood
           Advisory Committees, Community Development Corporations, or Registered
           Community Organizations. They can guide you through the planning
@@ -84,10 +86,10 @@ export default function TransformPropertyPage() {
           plan and show how your project can improve the community.
         </p>
 
-        <h3 className="text-xl font-bold mt-8 mb-4">
+        <h3 className="heading-xl font-bold mt-8 mb-4">
           Garden Justice Legal Initiative
         </h3>
-        <p>
+        <p className="body-md">
           The{" "}
           <a
             href="https://pubintlaw.org/cases-and-projects/garden-justice-legal-initiative-gjli/"
@@ -98,30 +100,21 @@ export default function TransformPropertyPage() {
           supports community gardens and urban farms, offering free legal help,
           policy research, and community education. They work with coalitions
           like{" "}
-          <a
-            href="https://soilgeneration.org/"
-            className="link"
-          >
+          <a href="https://soilgeneration.org/" className="link">
             Soil Generation
           </a>{" "}
           to empower residents to use vacant land for gardens and farming,
           providing tools and information through training sessions and their
           online resource,{" "}
-          <a
-            href="https://groundedinphilly.org/"
-            className="link"
-          >
+          <a href="https://groundedinphilly.org/" className="link">
             Grounded in Philly
           </a>
           .
         </p>
 
-        <h3 className="text-xl font-bold mt-8 mb-4">StreetBoxPHL</h3>
-        <p>
-          <a
-            href="https://streetboxphl.com/"
-            className="link"
-          >
+        <h3 className="heading-xl font-bold mt-8 mb-4">StreetBoxPHL</h3>
+        <p className="body-md">
+          <a href="https://streetboxphl.com/" className="link">
             StreetBoxPHL
           </a>{" "}
           helps community groups revitalize urban spaces by making parklets,
@@ -131,8 +124,8 @@ export default function TransformPropertyPage() {
           and help with insurance requirements.
         </p>
 
-        <h3 className="text-xl font-bold mt-8 mb-4">Park in a Truck</h3>
-        <p>
+        <h3 className="heading-xl font-bold mt-8 mb-4">Park in a Truck</h3>
+        <p className="body-md">
           <a
             href="https://www.jefferson.edu/academics/colleges-schools-institutes/architecture-and-the-built-environment/programs/landscape-architecture/park-in-a-truck.html"
             className="link"
@@ -152,11 +145,11 @@ export default function TransformPropertyPage() {
           communities create and maintain their parks.
         </p>
 
-        <h2 className="text-2xl font-bold mt-8">
+        <h2 className="heading-2xl font-bold mt-8">
           What else should I think about?
         </h2>
 
-        <p>
+        <p className="body-md">
           <Accordion variant="light" selectionMode="multiple">
             <AccordionItem
               key="1"

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -123,7 +123,7 @@
 
 .customized-map *,
 .customized-map .mapboxgl-ctrl-geocoder--input {
-  @apply font-body;
+  @apply font-body body-md;
 }
 
 .mapboxgl-ctrl-legend {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -46,9 +46,83 @@
   html {
     @apply font-body;
   }
+
+  /* Fallback variables for browsers that don't support clamp */
+  @supports (font-size: clamp(1rem, 1vw, 1rem)) {
+    :root {
+      --font-size-sm: clamp(0.89rem, -0.22vw + 0.94rem, 0.77rem);
+      --font-size-md: clamp(1rem, 0vw + 1rem, 1rem);
+      --font-size-lg: clamp(1.13rem, 0.32vw + 1.05rem, 1.3rem);
+      --font-size-xl: clamp(1.27rem, 0.77vw + 1.07rem, 1.69rem);
+      --font-size-2xl: clamp(1.42rem, 1.41vw + 1.07rem, 2.2rem);
+      --font-size-3xl: clamp(1.6rem, 2.28vw + 1.03rem, 2.86rem);
+    }
+  }
+  /* Fallback variables for browsers that don't support clamp */
+  @supports not (font-size: clamp(1rem, 1vw, 1rem)) {
+    :root {
+      --font-size-sm: 0.89rem;
+      --font-size-md: 1rem;
+      --font-size-lg: 1.13rem;
+      --font-size-xl: 1.27rem;
+      --font-size-2xl: 1.42rem;
+      --font-size-3xl: 1.6rem;
+    }
+    @media screen and (min-width: 1280px) {
+      :root {
+        --font-size-sm: 0.77rem;
+        --font-size-md: 1rem;
+        --font-size-lg: 1.3rem;
+        --font-size-xl: 1.69rem;
+        --font-size-2xl: 2.2rem;
+        --font-size-3xl: 2.86rem;
+      }
+    }
+  }
+  .heading-3xl {
+    font-size: var(--font-size-3xl);
+    font-family: var(--font-family);
+    font-weight: 800;
+  }
+  .heading-2xl {
+    font-size: var(--font-size-2xl);
+    font-family: var(--font-family);
+    font-weight: 800;
+  }
+  .heading-xl {
+    font-size: var(--font-size-xl);
+    font-family: var(--font-family);
+    font-weight: bold;
+  }
+  .heading-lg {
+    font-size: var(--font-size-lg);
+    font-family: var(--font-family);
+    font-weight: bold;
+  }
+  .heading-md {
+    font-size: var(--font-size-md);
+    font-family: var(--font-family);
+    font-weight: bold;
+  }
+  .body-lg {
+    font-size: var(--font-size-lg);
+    font-family: var(--font-family);
+    font-weight: regular;
+  }
+  .body-md {
+    font-size: var(--font-size-md);
+    font-family: var(--font-family);
+    font-weight: regular;
+  }
+  .body-sm {
+    font-size: var(--font-size-sm);
+    font-family: var(--font-family);
+    font-weight: regular;
+  }
 }
 
-.customized-map *, .customized-map .mapboxgl-ctrl-geocoder--input {
+.customized-map *,
+.customized-map .mapboxgl-ctrl-geocoder--input {
   @apply font-body;
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,14 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    "eslint-plugin-custom-rules/**/*.js"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## Description
This PR adds an eslint rule to enforce classname usages of `heading-*` and `body-*` classes over `text-*` size classes, and updates the font sizes across the app to conform to this style guide. 

## Testing eslint rule updates
If a user adds tailwind font size classes of `text-sm` to `text-9xl` to any element, they should receive an eslint warning of: ```Use `heading-*` or `body-*` classes instead of specific `text-` size classes.eslint(custom-rules/no-text-size-class)```

<img width="473" alt="image" src="https://github.com/CodeForPhilly/vacant-lots-proj/assets/8061917/3ff695e6-06ad-4be3-bc8d-22ce8c7534bf">

## Testing UI changes
Due to the reach of these changes, screenshots won't be explicitly included, but the reviewer should test by opening these files as provided in the acceptance criteria, and seeing that the styles and sizings match (as described in https://github.com/CodeForPhilly/vacant-lots-proj/issues/279):
> - Landing page https://share.cleanshot.com/7zJhPJnB
> - Find Properties https://share.cleanshot.com/dpV4xQWH
> - Filter https://share.cleanshot.com/fFfg0gPR
> - Property https://share.cleanshot.com/s1dbbFDX
> - Content pages (Get Access, Transform a Property, Summary, Methodology) https://share.cleanshot.com/1X6mPr80


Closes #279 