### PR TITLE
jgaye/310 fix side panel loading state

### DIFF
--- a/src/app/components/PropertyDetailSection.tsx
+++ b/src/app/components/PropertyDetailSection.tsx
@@ -61,7 +61,7 @@ const PropertyDetailSection: FC<PropertyDetailSectionProps> = ({
   }, [page, featuresInView]);
 
   return loading ? (
-    <Spinner />
+    <Spinner className="flex flex-wrap" />
   ) : selectedProperty ? (
     <SinglePropertyDetail
       property={selectedProperty}

--- a/src/app/components/PropertyDetailSection.tsx
+++ b/src/app/components/PropertyDetailSection.tsx
@@ -61,7 +61,15 @@ const PropertyDetailSection: FC<PropertyDetailSectionProps> = ({
   }, [page, featuresInView]);
 
   return loading ? (
-    <Spinner className="flex flex-wrap" />
+    <div>
+      {/* Center vertically in screen */}
+      <div className="flex w-full justify-center p-4 mt-24">
+        <p className="body-md">Loading properties</p>
+      </div>
+      <div className="flex w-full justify-center">
+        <Spinner />
+      </div>
+    </div>
   ) : selectedProperty ? (
     <SinglePropertyDetail
       property={selectedProperty}

--- a/src/app/components/SidePanelControlBar.tsx
+++ b/src/app/components/SidePanelControlBar.tsx
@@ -7,12 +7,14 @@ type SidePanelControlBarProps = {
   currentView: BarClickOptions;
   setCurrentView: (view: BarClickOptions) => void;
   featureCount: number;
+  loading: boolean;
 };
 
 const SearchBarComponent: FC<SidePanelControlBarProps> = ({
   currentView,
   setCurrentView,
   featureCount,
+  loading,
 }) => {
   const handleClick = (view: BarClickOptions) => {
     if (view === currentView) {
@@ -26,7 +28,11 @@ const SearchBarComponent: FC<SidePanelControlBarProps> = ({
     setCurrentView(currentView === "detail" ? "list" : "detail");
   };
 
-  return (
+  return loading ? (
+    <div className="flex w-full justify-center">
+      <h1 className="heading-md">Fetching results</h1>
+    </div>
+  ) : (
     <div className="flex justify-between items-center bg-white p-2 h-12">
       {/* Left-aligned content: Total Properties in View */}
       <div className="px-4 py-2">

--- a/src/app/components/SidePanelControlBar.tsx
+++ b/src/app/components/SidePanelControlBar.tsx
@@ -29,9 +29,7 @@ const SearchBarComponent: FC<SidePanelControlBarProps> = ({
   };
 
   return loading ? (
-    <div className="flex w-full justify-center">
-      <h1 className="heading-md">Fetching results</h1>
-    </div>
+    <div>{/* Keep empty while loading */}</div>
   ) : (
     <div className="flex justify-between items-center bg-white p-2 h-12">
       {/* Left-aligned content: Total Properties in View */}

--- a/src/app/map/page.tsx
+++ b/src/app/map/page.tsx
@@ -52,6 +52,7 @@ const Page: FC = () => {
                         currentView={currentView}
                         setCurrentView={setCurrentView}
                         featureCount={featureCount}
+                        loading={loading}
                       />
                     </div>
                   )}

--- a/src/app/map/page.tsx
+++ b/src/app/map/page.tsx
@@ -20,7 +20,7 @@ const Page: FC = () => {
   const [featuresInView, setFeaturesInView] = useState<any[]>([]);
   const [featureCount, setFeatureCount] = useState<number>(0);
   const [currentView, setCurrentView] = useState<BarClickOptions>("detail");
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(true);
   const [selectedProperty, setSelectedProperty] =
     useState<MapboxGeoJSONFeature | null>(null);
 


### PR DESCRIPTION
# Related issue
Solving issue #310 

# Changes
1. Display a text and spinner in the PropertyDetailSection while properties are being loaded
2. Hide the SidePanelControlBar while properties are being loaded

Design based on Slack conversation [here](https://codeforphilly.slack.com/archives/C05H9QBMP96/p1709839246741599).

# How to test
Start the server (with backend data) and go to the [localhost:3000/map](localhost:3000/map) page. While the map and properties are being loaded from the backend, the text and spinner will be displayed on the right hand side.  
The text and spinner should be replaced by the buttons of the SidePanelControlBar and the content of the PropertyDetailSection as soon as the data is available.  
NB: if you use the React Developer Tools, you can toggle the `loading` prop to `true` in the Components to re-display the loading state, as shown in the screenshot attached
![image](https://github.com/CodeForPhilly/vacant-lots-proj/assets/4049458/1d92f894-0c0b-4d04-a38f-397a0def1784)
