### PR TITLE
Bacitracin/299 prop card a11y

### DIFF
--- a/src/app/components/PropertyCard.tsx
+++ b/src/app/components/PropertyCard.tsx
@@ -37,10 +37,17 @@ const PropertyCard = ({ feature, setSelectedProperty }: PropertyCardProps) => {
   const formattedAddress = toTitleCase(address);
   const priorityClass = getPriorityClass(priority_level);
 
+  const handleClick = () => setSelectedProperty(feature);
+  const handleKeyDown = (e: React.KeyboardEvent): void  => {
+    if (e.key === 'Enter' || e.key === 'Space') {
+      handleClick()
+    }
+  };
+
   return (
     <div
       className="max-w-sm w-full md:w-1/2 p-2 cursor-pointer"
-      onClick={() => setSelectedProperty(feature)}
+      onClick={handleClick}
     >
       <div className="max-w-sm w-full p-4">
         <div className="bg-white rounded-md overflow-hidden">
@@ -50,14 +57,14 @@ const PropertyCard = ({ feature, setSelectedProperty }: PropertyCardProps) => {
           >
             <Image
               src={image}
-              alt={`Property at ${formattedAddress}`}
+              alt=""
               layout="fill"
               objectFit="cover"
               unoptimized
             />
           </div>
           <div className="p-2">
-            <div className="font-bold heading-lg">{formattedAddress}</div>
+            <button className="font-bold heading-lg" onKeyDown={handleKeyDown}>{formattedAddress}</button>
             <div className="text-gray-700 body-sm">
               {guncrime_density} Gun Crime Rate
             </div>

--- a/src/app/components/SinglePropertyDetail.tsx
+++ b/src/app/components/SinglePropertyDetail.tsx
@@ -78,7 +78,7 @@ const SinglePropertyDetail = ({
           style={{
             backgroundColor: "white",
           }}
-          onClick={() => setSelectedProperty(null)}
+          onPress={() => setSelectedProperty(null)}
         >
           <ArrowLeft color="#3D3D3D" size={24} />{" "}
           <span className="body-md">Back</span>{" "}


### PR DESCRIPTION
For https://github.com/CodeForPhilly/vacant-lots-proj/issues/299

Some updates to make the property cards in the list keyboard navigable.
- I went with making the address a button instead of a link because the url doesn't currently change when you click to see the single property detail.
- Made card image decorative (left the description on single property view, TBD on whether we want to keep that or not)
- The whole card is clickable