### PR TITLE
feat(303): add fullscreen streetview embed to the SinglePropertyDetail view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ data/src/tmp
 # misc
 .DS_Store
 *.pem
+.vscode
 
 # debug
 npm-debug.log*

--- a/src/app/components/PropertyDetailSection.tsx
+++ b/src/app/components/PropertyDetailSection.tsx
@@ -1,4 +1,4 @@
-import { FC, useState, useMemo } from "react";
+import { FC, useState, useMemo, SetStateAction, Dispatch } from "react";
 import {
   Table,
   TableHeader,
@@ -35,6 +35,7 @@ interface PropertyDetailSectionProps {
   loading: boolean;
   selectedProperty: MapboxGeoJSONFeature | null;
   setSelectedProperty: (property: MapboxGeoJSONFeature | null) => void;
+  setIsStreetViewModalOpen: Dispatch<SetStateAction<boolean>>;
 }
 
 const PropertyDetailSection: FC<PropertyDetailSectionProps> = ({
@@ -43,6 +44,7 @@ const PropertyDetailSection: FC<PropertyDetailSectionProps> = ({
   loading,
   selectedProperty,
   setSelectedProperty,
+  setIsStreetViewModalOpen,
 }) => {
   const [page, setPage] = useState(1);
 
@@ -66,6 +68,7 @@ const PropertyDetailSection: FC<PropertyDetailSectionProps> = ({
     <SinglePropertyDetail
       property={selectedProperty}
       setSelectedProperty={setSelectedProperty}
+      setIsStreetViewModalOpen={setIsStreetViewModalOpen}
     />
   ) : (
     <>

--- a/src/app/components/PropertyMap.tsx
+++ b/src/app/components/PropertyMap.tsx
@@ -30,6 +30,7 @@ import { MapboxGeoJSONFeature } from "mapbox-gl";
 import MapboxGeocoder from "@mapbox/mapbox-gl-geocoder";
 import "@mapbox/mapbox-gl-geocoder/dist/mapbox-gl-geocoder.css";
 import ZoomModal from "./ZoomModal";
+import { Coordinates } from "../types";
 
 const layerStyle: FillLayer = {
   id: "vacant_properties_tiles",
@@ -76,6 +77,7 @@ interface PropertyMapProps {
   selectedProperty: MapboxGeoJSONFeature | null;
   setSelectedProperty: (property: MapboxGeoJSONFeature | null) => void;
   setFeatureCount: Dispatch<SetStateAction<number>>;
+  setCoordinates: Dispatch<SetStateAction<Coordinates>>;
 }
 const PropertyMap: FC<PropertyMapProps> = ({
   setFeaturesInView,
@@ -83,6 +85,7 @@ const PropertyMap: FC<PropertyMapProps> = ({
   selectedProperty,
   setSelectedProperty,
   setFeatureCount,
+  setCoordinates,
 }) => {
   const { appFilter } = useFilter();
   const [popupInfo, setPopupInfo] = useState<any | null>(null);
@@ -126,6 +129,10 @@ const PropertyMap: FC<PropertyMapProps> = ({
 
       if (features.length > 0) {
         setSelectedProperty(features[0]);
+        setCoordinates({
+          lng: event.lngLat.lng,
+          lat: event.lngLat.lat,
+        });
         setPopupInfo({
           longitude: event.lngLat.lng,
           latitude: event.lngLat.lat,
@@ -271,6 +278,11 @@ const PropertyMap: FC<PropertyMapProps> = ({
 
             map.flyTo({
               center: pointForMap,
+            });
+
+            setCoordinates({
+              lng: finalPoint[0].toString(),
+              lat: finalPoint[1].toString(),
             });
 
             setPopupInfo({

--- a/src/app/components/SinglePropertyDetail.tsx
+++ b/src/app/components/SinglePropertyDetail.tsx
@@ -10,17 +10,21 @@ import {
   Tree,
   ProhibitInset,
   PiggyBank,
+  ArrowsOut,
 } from "@phosphor-icons/react";
 import SinglePropertyInfoCard from "./SinglePropertyInfoCard";
+import { Dispatch, SetStateAction } from "react";
 
 interface PropertyDetailProps {
   property: MapboxGeoJSONFeature | null;
   setSelectedProperty: (property: MapboxGeoJSONFeature | null) => void;
+  setIsStreetViewModalOpen: Dispatch<SetStateAction<boolean>>;
 }
 
 const SinglePropertyDetail = ({
   property,
   setSelectedProperty,
+  setIsStreetViewModalOpen,
 }: PropertyDetailProps) => {
   if (!property) return null;
   const { properties } = property;
@@ -82,6 +86,13 @@ const SinglePropertyDetail = ({
             objectFit="cover"
             unoptimized
           />
+          <button
+            className="absolute top-4 right-4 bg-white p-[10px] rounded-md"
+            onClick={() => setIsStreetViewModalOpen(true)}
+            aria-label="Open full screen street view map"
+          >
+            <ArrowsOut color="#3D3D3D" size={24} />
+          </button>
         </div>
       </div>
       <div className="py-4 px-2">

--- a/src/app/components/StreetView.tsx
+++ b/src/app/components/StreetView.tsx
@@ -1,0 +1,59 @@
+import React from "react";
+
+interface StreetViewProps {
+  lat: string;
+  lng: string;
+  yaw: string;
+  pitch: string;
+  fov: string;
+}
+
+/**
+ * Takes a lng/lat and generates an embed-able google street view url.
+ *
+ * Warning: This is manually crafted and not linked to any API,
+ *          so if Google decided to change how they craft their
+ *          Embedding URL structure, this would break.
+ *
+ * @param lat - The latitude of the location.
+ * @param lng - The longitude of the location.
+ * @param yaw - The yaw angle of the street view.
+ * @param pitch - The pitch angle of the street view.
+ * @param fov - The field of view of the street view.
+ * @returns The rendered street view component.
+ */
+const StreetView: React.FC<StreetViewProps> = ({
+  lat,
+  lng,
+  yaw,
+  pitch,
+  fov,
+}) => {
+  const generateStreetViewURL = (
+    lat: string,
+    lng: string,
+    yaw: string,
+    pitch: string,
+    fov: string
+  ) => {
+    const base_url =
+      "https://www.google.com/maps/embed?pb=!4v[TIMESTAMP]!6m8!1m7![PANO_ID]";
+    const orientation = `!2m2!1d${lat}!2d${lng}!3f${yaw}!4f${pitch}!5f${fov}`;
+    return base_url + orientation;
+  };
+
+  const streetViewURL = generateStreetViewURL(lat, lng, yaw, pitch, fov);
+
+  return (
+    <iframe
+      src={streetViewURL}
+      width="100%"
+      height="100%"
+      style={{ border: 0 }}
+      allowFullScreen={false}
+      loading="lazy"
+    ></iframe>
+  );
+};
+
+export default StreetView;

--- a/src/app/map/page.tsx
+++ b/src/app/map/page.tsx
@@ -13,6 +13,9 @@ import {
 } from "../components";
 import Hotjar from "../components/Hotjar";
 import { MapboxGeoJSONFeature } from "mapbox-gl";
+import StreetView from "../components/StreetView";
+import { Coordinates } from "../types";
+import { X } from "@phosphor-icons/react";
 
 export type BarClickOptions = "filter" | "download" | "detail" | "list";
 
@@ -23,14 +26,49 @@ const Page: FC = () => {
   const [loading, setLoading] = useState(false);
   const [selectedProperty, setSelectedProperty] =
     useState<MapboxGeoJSONFeature | null>(null);
+  const [isStreetViewModalOpen, setIsStreetViewModalOpen] =
+    useState<boolean>(false);
+  const [coordinates, setCoordinates] = useState<Coordinates>({
+    lat: null,
+    lng: null,
+  });
 
   return (
     <FilterProvider>
       <NextUIProvider>
         <div className="flex flex-col h-screen">
-          <a className="font-bold border-solid border-black bg-white transition left-0 absolute p-3 m-3 -translate-y-16 focus:translate-y-0 z-50" href="#main" tabIndex={0}>Skip to main content</a>
+          <a
+            className="font-bold border-solid border-black bg-white transition left-0 absolute p-3 m-3 -translate-y-16 focus:translate-y-0 z-50"
+            href="#main"
+            tabIndex={0}
+          >
+            Skip to main content
+          </a>
           <Header />
+
           <main className="flex flex-grow overflow-hidden" id="main">
+            {isStreetViewModalOpen && coordinates && (
+              <div
+                id="street-view-overlay"
+                className="fixed z-20 h-[100lvh] w-[100lvw] bg-black"
+              >
+                <button
+                  className="absolute top-4 right-4 bg-white p-[10px] rounded-md flex flex-row space-x-1 items-center"
+                  onClick={() => setIsStreetViewModalOpen(false)}
+                  aria-label="Close full screen street view map"
+                >
+                  <X color="#3D3D3D" size={20} />
+                  <span className="leading-0">Close</span>
+                </button>
+                <StreetView
+                  lat={coordinates.lat || ""}
+                  lng={coordinates.lng || ""}
+                  yaw="180"
+                  pitch="5"
+                  fov="0.7"
+                />
+              </div>
+            )}
             <div className="flex-grow overflow-auto">
               <PropertyMap
                 setFeaturesInView={setFeaturesInView}
@@ -38,6 +76,7 @@ const Page: FC = () => {
                 selectedProperty={selectedProperty}
                 setSelectedProperty={setSelectedProperty}
                 setFeatureCount={setFeatureCount}
+                setCoordinates={setCoordinates}
               />
             </div>
             <SidePanel>
@@ -81,6 +120,7 @@ const Page: FC = () => {
                       loading={loading}
                       selectedProperty={selectedProperty}
                       setSelectedProperty={setSelectedProperty}
+                      setIsStreetViewModalOpen={setIsStreetViewModalOpen}
                     />
                   )}
                 </>

--- a/src/app/types.tsx
+++ b/src/app/types.tsx
@@ -1,0 +1,4 @@
+export interface Coordinates {
+  lat: string | null;
+  lng: string | null;
+}


### PR DESCRIPTION
## Description
This PR adds a fullscreen Google streetview to the `SinglePropertyDetail` view.

To the reviewer: please note that the way we're generating the embed url is a workaround, and is susceptible to breaking if Google were to ever change how they're structuring their embedding URL.

For how I got the URL in [`StreetView.tsx`](https://github.com/CodeForPhilly/vacant-lots-proj/commit/82f435e6859f57d5d7434ccc6f015a3d98acf394#diff-90f0b4840550f8b5723a8f4b5d882bd090cabdd20fe28f8519994fd61ee9251fR39-R42), I pretty much took a few randomized streetview embed URLs, found the deltas between them, and derived the parameters they're updating to generate the url for the different locations.

Pros to this implementation:
- Free

Cons:
- As far as I know, this url structure isn't documented anywhere and could feasible break anytime google decided to change it (though I'm not sure how likely that is).
- Because we're not fetching the view through the streeview API, we have no way of knowing how to set the `yaw`, `pitch`, and `fov` values when generating the view, and so while they've been hardcoded to reasonable values, the resulting initial streetview view could be in the opposite "direction" of the actual address.

## Testing
From `/map`, select a property, and in the detail pane, click the "expand" arrows on the top right of the image.

https://github.com/CodeForPhilly/vacant-lots-proj/assets/8061917/8b250d0b-8f77-42c4-ba36-b6de97a330ac

Closes #303 