### PR TITLE
feat(398): fix map legend font size

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -141,10 +141,12 @@
 
 /* Styles for the mapbox legend pane. */
 .mapboxgl-ctrl-legend-pane summary {
+  font-size: 16px;
   text-transform: capitalize;
 }
 
 .mapboxgl-ctrl-legend-pane ul.list li {
+  font-size: 14px;
   text-transform: capitalize;
   color: #173009;
 }


### PR DESCRIPTION
## Description

This PR increases the font size of of the legend according to the spec described here: https://share.cleanshot.com/2N94qLst

**Before**
![Screenshot 2024-03-12 at 9 57 17 PM](https://github.com/CodeForPhilly/vacant-lots-proj/assets/8061917/3c193d5d-8ce7-4c73-a2d7-fd8e4afea218)

**After**
![GTknw](https://github.com/CodeForPhilly/vacant-lots-proj/assets/8061917/59a3b72a-c056-40af-b05f-54e1dcc6bc8f)


Closes #398