### PR TITLE
259-responsive-nav-feat-css-nav-item-cleanup

### DIFF
--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -1,17 +1,8 @@
-import {
-  Navbar,
-  NavbarContent,
-  NavbarBrand,
-  NavbarItem,
-  Dropdown,
-  DropdownTrigger,
-  DropdownMenu,
-  DropdownItem,
-  Button,
-} from "@nextui-org/react";
+import { Navbar, NavbarContent, NavbarBrand } from "@nextui-org/react";
 import IconLink from "./IconLink";
 import Link from "next/link";
 import Image from "next/image";
+import MobileNav from "./MobileNav";
 import {
   MapPin,
   Hand,
@@ -20,22 +11,14 @@ import {
   Key,
   Tree,
 } from "@phosphor-icons/react";
-
 // Apply multiple CSS classes using CSS Modules
 // const buttonClasses = `${styles.button} ${primary ? styles.primary : ""} ${
 //   large ? styles.large : ""
 // }`;
 
 const Header = () => (
-  <Navbar
-    maxWidth="full"
-    position="sticky"
-    height="auto"
-    isBordered
-    classNames={{
-      item: ["activeIconLinkNav"],
-    }}
-  >
+  <Navbar maxWidth="full" position="sticky" height="auto" isBordered>
+    <MobileNav />
     <NavbarContent
       className="hidden sm:flex basis-1/5 sm:basis-full"
       style={{ paddingTop: "16px", paddingBottom: "16px", paddingLeft: "32px" }}

--- a/src/app/components/MobileNav.tsx
+++ b/src/app/components/MobileNav.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import React, { FC } from "react";
+import Image from "next/image";
+import {
+  Navbar,
+  NavbarContent,
+  NavbarBrand,
+  NavbarMenuToggle,
+  NavbarMenu,
+  Link,
+} from "@nextui-org/react";
+import IconLink from "./IconLink";
+import { MapPin, Hand, Info, List, Binoculars, X } from "@phosphor-icons/react";
+const MobileNav: FC = () => {
+  const [isMenuOpen, setIsMenuOpen] = React.useState(false);
+
+  return (
+    <Navbar
+      className="sm:hidden h-24"
+      isBlurred={false}
+      onMenuOpenChange={setIsMenuOpen}
+    >
+      <NavbarContent>
+        <NavbarBrand>
+          <Link href="/">
+            <Image
+              src="/logo.svg"
+              alt="Clean & Green Philly Logo"
+              width={100}
+              height={65}
+            />
+          </Link>
+        </NavbarBrand>
+
+        <NavbarMenuToggle
+          aria-label={isMenuOpen ? "Close menu" : "Open menu"}
+          className="sm:hidden flex-end w-fit"
+          icon={
+            <div className="flex">
+              <List className="h-6 w-6" /> Menu
+            </div>
+          }
+        ></NavbarMenuToggle>
+      </NavbarContent>
+
+      <NavbarMenu className="left-2/4 z-50 px-0 w-fit mobileIconLinkNav">
+        <IconLink
+          icon={<MapPin className="h-6 w-6" />}
+          text="Find Properties"
+          href="/map"
+        />
+
+        <IconLink
+          icon={<Hand className="h-6 w-6" />}
+          text="Take Action"
+          href="/take-action-overview"
+        />
+
+        <IconLink
+          icon={<Info className="h-6 w-6" />}
+          text="About"
+          href="/about"
+        />
+      </NavbarMenu>
+    </Navbar>
+  );
+};
+
+export default MobileNav;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -211,7 +211,6 @@ a .bg-color-none {
   color: #0c5c00;
   background-color: #e9ffe5;
   border-radius: 12px;
-  width: 100%;
   justify-content: left;
 }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -124,13 +124,14 @@
     @apply text-gray-900;
     @apply items-center;
     @apply items-center;
-    @apply active:bg-[#E9FFE5];
+    @apply active:bg-[#C2F5BA];
     @apply active:text-green-700;
     @apply focus:text-green-700;
     @apply focus:bg-[#E9FFE5];
-    @apply hover:bg-gray-100;
     @apply bg-color-none;
     @apply hover:bg-gray-10;
+    @apply rounded-medium;
+    @apply max-sm:hover:bg-[#ffffff];
   }
 
   .activeIconLinkNav {
@@ -138,6 +139,7 @@
     @apply relative;
     @apply h-full;
     @apply items-center;
+    @apply rounded-medium
     @apply data-[active=true]:bottom-0;
     @apply data-[active=true]:left-0;
     @apply data-[active=true]:right-0;
@@ -146,6 +148,25 @@
     @apply data-[active=true]:bg-[#E9FFE5];
     @apply data-[active=true]:text-[#E9FFE5];
     @apply data-[active=true]:rounded-medium;
+  }
+  .mobileIconLinkNav {
+    @apply px-0;
+    @apply text-base;
+    @apply max-h-40;
+    @apply overflow-hidden;
+    @apply fixed;
+    @apply left-2/4;
+    @apply top-20;
+    @apply w-full;
+    @apply z-50;
+    @apply shadow-2xl;
+    @apply rounded-md;
+    @apply border-1;
+    @apply border-gray-200;
+    @apply bg-gray-0;
+  }
+  .mobileIconLinkNav:hover {
+    @apply bg-gray-0;
   }
 }
 
@@ -189,9 +210,13 @@ a .bg-color-none {
 .active-state-nav {
   color: #0c5c00;
   background-color: #e9ffe5;
+  border-radius: 12px;
+  width: 100%;
+  justify-content: left;
 }
 
 .active-state-nav:hover {
   color: #0c5c00;
   background-color: #c2f5ba;
+  border-radius: 12px;
 }


### PR DESCRIPTION
### Mobile Navigation Added

I used Next UI's NavbarMenuToggle component to add the mobile navigation to the site. I tried to follow the design closely and used many tailwind classes to edit the default component to replicate it. The mobile breakpoint in 640. We should consider a new issue for tablet, which would be between 768px and 1024px I believe.

### There is room for improvement for a11y 
The DOM order is not accurate. For some reason the menu list is rendering at the end of the page and making the links appear at the end of the tab order when they should appear as the 4th, 5th, and 6th option after selecting the menu to open. This is only on mobile so it's not a huge issue but definitely needs a new issue to correct this as responsive design helps users who zoom in at 300% or more on desktops as well. 

### CSS Updates to nav items
I updated some CSS selectors and adjusted some styling to better match the Figma design 

This closes issue #259 (https://github.com/CodeForPhilly/vacant-lots-proj/issues/259)