### PR TITLE
413 - Format number into string with comma

### DIFF
--- a/src/components/SidePanelControlBar.tsx
+++ b/src/components/SidePanelControlBar.tsx
@@ -37,7 +37,8 @@ const SearchBarComponent: FC<SidePanelControlBarProps> = ({
       {/* Left-aligned content: Total Properties in View */}
       <div className="px-4 py-2">
         <h1 className="body-md">
-          <span className="font-bold">{featureCount}</span> Properties in View
+          <span className="font-bold">{featureCount.toLocaleString()}</span>{" "}
+          Properties in View
         </h1>
       </div>
 


### PR DESCRIPTION
For ticket #413 

# How to check  
Go to the /map page, and zoom out to have more than 1,000 properties. The number should be formatted with a comma between thousands and hundreds.  
Note that the formatting should adapt to the Locale of the browser, meaning that it can change if you are on a VPN to adapt to the country's way of writing numbers (for example 1.500 in France)

@Moylena 