### PR TITLE
400-add-iframe-title-to-street-view

### DIFF
--- a/src/components/StreetView.tsx
+++ b/src/components/StreetView.tsx
@@ -52,6 +52,7 @@ const StreetView: React.FC<StreetViewProps> = ({
       style={{ border: 0 }}
       allowFullScreen={false}
       loading="lazy"
+      title="Street View"
     ></iframe>
   );
 };


### PR DESCRIPTION
<img width="1684" alt="Screen Shot 2024-03-23 at 12 04 39 PM" src="https://github.com/CodeForPhilly/vacant-lots-proj/assets/61482332/16d192a9-fa63-41ee-b619-d43d1090ea82" alt="ANDI frame showing iframe title">

Added title to the iframe element for the Streetview component.

This closes issue https://github.com/CodeForPhilly/vacant-lots-proj/issues/400

I have been having trouble keeping my forked version up to date. Hopefully there are no conflicts. 
