### PR TITLE
Removed the word link between Atlas and external link icon #416

### DIFF
--- a/src/components/SinglePropertyDetail.tsx
+++ b/src/components/SinglePropertyDetail.tsx
@@ -120,7 +120,7 @@ const SinglePropertyDetail = ({
               color="primary"
               className="flex p-2 items-center gap-1 body-md"
             >
-              Atlas Link
+              Atlas
               <ArrowSquareOut className="inline h-6 w-6" aria-hidden="true" />
             </a>
           </div>


### PR DESCRIPTION
Removed the word link between Atlas and external link icon from the map detail page. 