### PR TITLE
Amberroseweeks/399 google street view focus trap

### DIFF
--- a/src/app/map/page.tsx
+++ b/src/app/map/page.tsx
@@ -13,11 +13,9 @@ import { FilterProvider } from "@/context/FilterContext";
 import { NextUIProvider } from "@nextui-org/react";
 import { X } from "@phosphor-icons/react";
 import { MapGeoJSONFeature } from "maplibre-gl";
-import ReactDOM from "react-dom";
 import StreetView from "../../components/StreetView";
 import { centroid } from "@turf/centroid";
 import { Position } from "geojson";
-// import FullScreenTrap from "./FullScreenTrap";
 
 export type BarClickOptions = "filter" | "download" | "detail" | "list";
 
@@ -202,9 +200,7 @@ const StreetViewModal: React.FC<{
         const outsideElement = document.getElementById(
           "outside-iframe-element"
         );
-        console.log("Outside element:", outsideElement);
         outsideElement?.focus();
-        console.log("Focused outside element");
       } else if (event.key === "Tab") {
         // Trap focus within the container
         const container = containerRef.current;
@@ -233,9 +229,7 @@ const StreetViewModal: React.FC<{
         const outsideElement = document.getElementById(
           "outside-iframe-element"
         );
-        console.log("Outside element:", outsideElement);
         outsideElement?.focus();
-        console.log("Focused outside element");
       }
     };
 
@@ -277,9 +271,11 @@ const StreetViewModal: React.FC<{
             <button
               onClick={onClose}
               tabIndex={0}
+              aria-label="Close full screen street view map"
               className="absolute top-4 right-4 bg-white p-[10px] rounded-md flex flex-row space-x-1 items-center"
             >
-              Close
+              <X color="#3D3D3D" size={20} />
+              <span className="leading-0">Close</span>
             </button>
             {children}
           </div>

--- a/src/components/SinglePropertyDetail.tsx
+++ b/src/components/SinglePropertyDetail.tsx
@@ -97,6 +97,7 @@ const SinglePropertyDetail = ({
             className="absolute top-4 right-4 bg-white p-[10px] rounded-md"
             onClick={() => setIsStreetViewModalOpen(true)}
             aria-label="Open full screen street view map"
+            id="outside-iframe-element"
           >
             <ArrowsOut color="#3D3D3D" size={24} />
           </button>


### PR DESCRIPTION
This closes issue: https://github.com/CodeForPhilly/vacant-lots-proj/issues/399

**Changes:**

- User's focus using the tab key is trapped inside the iframe
- Close button is first to receive focus when iframe is open
- focus is returned to trigger element when iframe is closed

**Consider adding in the future**

- Close iframe on ESC key press

I struggled with this a little, I had to refactor the close button and add new logic to the StreetViewModal to create a focus trap and allow for the close button to be within tab order. It's actually not in tab order now. It is focusable but difficult to find.

I tried to implement the ESC key as another way to close the full page iframe but when you interact with the iframe inside, the ESC key function will not fire. If you don't focus on the iframe the ESC will work. 

When the iframe is closed, the focus will return to the trigger element the button with the id "outside-iframe-element"