### PR TITLE
feat: add redirect from map to find-properties

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -8,4 +8,13 @@ module.exports = {
   images: {
     domains: ["storage.googleapis.com"],
   },
+  async redirects() {
+    return [
+      {
+        source: "/map",
+        destination: "/find-properties",
+        permanent: true,
+      },
+    ];
+  },
 };


### PR DESCRIPTION
## Description

This PR adds a permanent redirect from `/map` to `/find-properties` to ensure any `/map` links don't 404. This also ensures that any Google Search / SEO 'juice' to `/map` doesn't get lost but is also forwarded correctly.

Closes #488 