### PR TITLE
feat(395): make property selection back button sticky

### DIFF
--- a/src/components/SinglePropertyDetail.tsx
+++ b/src/components/SinglePropertyDetail.tsx
@@ -68,15 +68,8 @@ const SinglePropertyDetail = ({
   );
 
   return (
-    <div
-      className="w-full p-4"
-      style={{
-        paddingRight: "24px",
-        paddingBottom: "24px",
-        paddingLeft: "24px",
-      }}
-    >
-      <div className="pb-4">
+    <div className="w-full px-6 pb-6">
+      <div className="sticky top-0 py-4 z-10">
         <Button
           onPress={() => {
             setSelectedProperty(null);


### PR DESCRIPTION
## Description

Following the acceptance criteria of https://github.com/CodeForPhilly/vacant-lots-proj/issues/395, this PR makes the Back button of the single property selection pane sticky to the window.

## Demo

https://github.com/CodeForPhilly/vacant-lots-proj/assets/8061917/5ba2011f-9478-4c19-80c4-2d7435370a70

Closes https://github.com/CodeForPhilly/vacant-lots-proj/issues/395