### PR TITLE
Fix #462: Changed initial zoom & fixed mobile map

### DIFF
--- a/src/app/find-properties/[[...opa_id]]/page.tsx
+++ b/src/app/find-properties/[[...opa_id]]/page.tsx
@@ -45,9 +45,9 @@ const MapPage = ({ params }: MapPageProps) => {
   const prevCoordinateRef = useRef([]);
   const linkedPropertyRef = useRef<string | null>(null);
   const [initialViewState, setInitialViewState] = useState<ViewState>({
-    longitude: -75.15975924194129,
-    latitude: 39.9910071520824,
-    zoom: 13,
+    longitude: -75.1628565788269,
+    latitude: 39.97008211622267,
+    zoom: 11,
     bearing: 0,
     pitch: 0,
     padding: { top: 0, bottom: 0, left: 0, right: 0 },

--- a/src/app/find-properties/[[...opa_id]]/page.tsx
+++ b/src/app/find-properties/[[...opa_id]]/page.tsx
@@ -42,6 +42,7 @@ const MapPage = ({ params }: MapPageProps) => {
   const [smallScreenMode, setSmallScreenMode] = useState("map");
   const prevRef = useRef("map");
   const sizeRef = useRef(0);
+  const prevCoordinateRef = useRef([]);
   const linkedPropertyRef = useRef<string | null>(null);
   const [initialViewState, setInitialViewState] = useState<ViewState>({
     longitude: -75.15975924194129,
@@ -106,11 +107,12 @@ const MapPage = ({ params }: MapPageProps) => {
         feature.properties.OPA_ID.toString() ===
         linkedPropertyRef?.current?.toString()
     );
+
     if (
       linkedProperty &&
       linkedProperty.properties.OPA_ID !== selectedProperty?.properties.OPA_ID
     ) {
-      setSelectedProperty(linkedProperty);
+      setSelectedProperty(linkedProperty); 
       linkedPropertyRef.current = null;
     }
   }, [featuresInView, linkedPropertyRef.current]);
@@ -123,11 +125,10 @@ const MapPage = ({ params }: MapPageProps) => {
 
   const updateCurrentView = (view: BarClickOptions) => {
     setCurrentView(view === currentView ? "detail" : view);
-
     if (
       prevRef.current === "map" &&
       window.innerWidth < 640 &&
-      view === "filter"
+      (view === "filter" || (Object.keys(params).length === 0 && prevCoordinateRef.current.length !== 0))
     ) {
       setSmallScreenMode((prev: string) =>
         prev === "map" ? "properties" : "map"
@@ -180,6 +181,12 @@ const MapPage = ({ params }: MapPageProps) => {
     if (!selectedProperty) return;
     const propCentroid = centroid(selectedProperty.geometry);
     setStreetViewLocation(propCentroid.geometry.coordinates);
+
+    if (window.innerWidth < 640 && prevRef.current === "map") {
+      prevCoordinateRef.current = propCentroid.geometry.coordinates;
+      setSmallScreenMode("properties");
+    }  
+
   }, [selectedProperty]);
 
   return (
@@ -212,8 +219,9 @@ const MapPage = ({ params }: MapPageProps) => {
                   selectedProperty={selectedProperty}
                   setSelectedProperty={setSelectedProperty}
                   setFeatureCount={setFeatureCount}
-                  setSmallScreenMode={setSmallScreenMode}
                   initialViewState={initialViewState}
+                  prevCoordinate={prevCoordinateRef.current}
+                  setPrevCoordinate={() => prevCoordinateRef.current = []}
                 />
               ) : (
                 <div className="flex w-full h-full justify-center">

--- a/src/app/find-properties/[[...opa_id]]/page.tsx
+++ b/src/app/find-properties/[[...opa_id]]/page.tsx
@@ -41,7 +41,7 @@ const MapPage = ({ params }: MapPageProps) => {
   const [smallScreenMode, setSmallScreenMode] = useState("map");
   const prevRef = useRef("map");
   const sizeRef = useRef(0);
-  const prevCoordinateRef = useRef([]);
+  const prevCoordinateRef = useRef<Position | null>(null);
   const linkedPropertyRef = useRef<string | null>(null);
   const [initialViewState, setInitialViewState] = useState<ViewState>({
     longitude: -75.1628565788269,
@@ -129,7 +129,7 @@ const MapPage = ({ params }: MapPageProps) => {
       window.innerWidth < 640 &&
       (view === "filter" ||
         (Object.keys(params).length === 0 &&
-          prevCoordinateRef.current.length !== 0))
+          prevCoordinateRef.current))
     ) {
       setSmallScreenMode((prev: string) =>
         prev === "map" ? "properties" : "map"
@@ -221,7 +221,7 @@ const MapPage = ({ params }: MapPageProps) => {
                   setFeatureCount={setFeatureCount}
                   initialViewState={initialViewState}
                   prevCoordinate={prevCoordinateRef.current}
-                  setPrevCoordinate={() => (prevCoordinateRef.current = [])}
+                  setPrevCoordinate={() => (prevCoordinateRef.current = null)}
                 />
               ) : (
                 <div className="flex w-full h-full justify-center">

--- a/src/app/find-properties/[[...opa_id]]/page.tsx
+++ b/src/app/find-properties/[[...opa_id]]/page.tsx
@@ -36,9 +36,8 @@ const MapPage = ({ params }: MapPageProps) => {
     useState<MapGeoJSONFeature | null>(null);
   const [isStreetViewModalOpen, setIsStreetViewModalOpen] =
     useState<boolean>(false);
-  const [streetViewLocation, setStreetViewLocation] = useState<Position | null>(
-    null
-  );
+  const [streetViewLocation, setStreetViewLocation] =
+    useState<Position | null>(null);
   const [smallScreenMode, setSmallScreenMode] = useState("map");
   const prevRef = useRef("map");
   const sizeRef = useRef(0);
@@ -112,7 +111,7 @@ const MapPage = ({ params }: MapPageProps) => {
       linkedProperty &&
       linkedProperty.properties.OPA_ID !== selectedProperty?.properties.OPA_ID
     ) {
-      setSelectedProperty(linkedProperty); 
+      setSelectedProperty(linkedProperty);
       linkedPropertyRef.current = null;
     }
   }, [featuresInView, linkedPropertyRef.current]);
@@ -128,7 +127,9 @@ const MapPage = ({ params }: MapPageProps) => {
     if (
       prevRef.current === "map" &&
       window.innerWidth < 640 &&
-      (view === "filter" || (Object.keys(params).length === 0 && prevCoordinateRef.current.length !== 0))
+      (view === "filter" ||
+        (Object.keys(params).length === 0 &&
+          prevCoordinateRef.current.length !== 0))
     ) {
       setSmallScreenMode((prev: string) =>
         prev === "map" ? "properties" : "map"
@@ -185,8 +186,7 @@ const MapPage = ({ params }: MapPageProps) => {
     if (window.innerWidth < 640 && prevRef.current === "map") {
       prevCoordinateRef.current = propCentroid.geometry.coordinates;
       setSmallScreenMode("properties");
-    }  
-
+    }
   }, [selectedProperty]);
 
   return (
@@ -221,7 +221,7 @@ const MapPage = ({ params }: MapPageProps) => {
                   setFeatureCount={setFeatureCount}
                   initialViewState={initialViewState}
                   prevCoordinate={prevCoordinateRef.current}
-                  setPrevCoordinate={() => prevCoordinateRef.current = []}
+                  setPrevCoordinate={() => (prevCoordinateRef.current = [])}
                 />
               ) : (
                 <div className="flex w-full h-full justify-center">

--- a/src/components/PropertyMap.tsx
+++ b/src/components/PropertyMap.tsx
@@ -47,7 +47,6 @@ import { createPortal } from "react-dom";
 import { Tooltip } from "@nextui-org/react";
 import { Info } from "@phosphor-icons/react";
 import { centroid } from "@turf/centroid";
-import { BarClickOptions } from "@/app/find-properties/[[...opa_id]]/page";
 
 const MIN_MAP_ZOOM = 10;
 const MAX_MAP_ZOOM = 20;

--- a/src/components/PropertyMap.tsx
+++ b/src/components/PropertyMap.tsx
@@ -47,6 +47,7 @@ import { createPortal } from "react-dom";
 import { Tooltip } from "@nextui-org/react";
 import { Info } from "@phosphor-icons/react";
 import { centroid } from "@turf/centroid";
+import { BarClickOptions } from "@/app/find-properties/[[...opa_id]]/page";
 
 const MIN_MAP_ZOOM = 10;
 const MAX_MAP_ZOOM = 20;
@@ -116,8 +117,9 @@ interface PropertyMapProps {
   selectedProperty: MapGeoJSONFeature | null;
   setSelectedProperty: (property: MapGeoJSONFeature | null) => void;
   setFeatureCount: Dispatch<SetStateAction<number>>;
-  setSmallScreenMode: Dispatch<SetStateAction<string>>;
   initialViewState: ViewState;
+  prevCoordinate: number[];
+  setPrevCoordinate: () => void;
 }
 const PropertyMap: FC<PropertyMapProps> = ({
   setFeaturesInView,
@@ -125,8 +127,9 @@ const PropertyMap: FC<PropertyMapProps> = ({
   selectedProperty,
   setSelectedProperty,
   setFeatureCount,
-  setSmallScreenMode,
   initialViewState,
+  prevCoordinate,
+  setPrevCoordinate,
 }) => {
   const { appFilter } = useFilter();
   const [popupInfo, setPopupInfo] = useState<any | null>(null);
@@ -307,6 +310,10 @@ const PropertyMap: FC<PropertyMapProps> = ({
     if (!map) return;
     if (!selectedProperty) {
       setPopupInfo(null);
+      if (window.innerWidth < 640 && prevCoordinate.length !== 0) {
+        map.setCenter(prevCoordinate);
+        setPrevCoordinate();
+      }
     } else {
       const propCentroid = centroid(selectedProperty.geometry);
       moveMap(propCentroid.geometry.coordinates as LngLatLike);

--- a/src/components/PropertyMap.tsx
+++ b/src/components/PropertyMap.tsx
@@ -47,6 +47,7 @@ import { createPortal } from "react-dom";
 import { Tooltip } from "@nextui-org/react";
 import { Info } from "@phosphor-icons/react";
 import { centroid } from "@turf/centroid";
+import { Position } from "geojson";
 
 const MIN_MAP_ZOOM = 10;
 const MAX_MAP_ZOOM = 20;
@@ -117,7 +118,7 @@ interface PropertyMapProps {
   setSelectedProperty: (property: MapGeoJSONFeature | null) => void;
   setFeatureCount: Dispatch<SetStateAction<number>>;
   initialViewState: ViewState;
-  prevCoordinate: number[];
+  prevCoordinate: Position | null;
   setPrevCoordinate: () => void;
 }
 const PropertyMap: FC<PropertyMapProps> = ({
@@ -309,8 +310,8 @@ const PropertyMap: FC<PropertyMapProps> = ({
     if (!map) return;
     if (!selectedProperty) {
       setPopupInfo(null);
-      if (window.innerWidth < 640 && prevCoordinate.length !== 0) {
-        map.setCenter(prevCoordinate);
+      if (window.innerWidth < 640 && prevCoordinate) {
+        map.setCenter(prevCoordinate as LngLatLike);
         setPrevCoordinate();
       }
     } else {


### PR DESCRIPTION
## Description
This PR addresses issue #462 and part of #442 (original: #260, 3 of this [comment](https://github.com/CodeForPhilly/vacant-lots-proj/pull/442#issuecomment-2005564609)). 

Map on initial load is zoomed out to include the rest of the city.  The new map implementation broke one of the expected behaviors in #442 which I resolved along the way. 

## Testing/Proof
### Initial load of map for different screen sizes 

https://github.com/CodeForPhilly/vacant-lots-proj/assets/28910543/85ce56a8-54ac-48a2-a98c-8725525d8e13


### Clicking on map in mobile goes directly to property details 

https://github.com/CodeForPhilly/vacant-lots-proj/assets/28910543/719eb4a1-4e2d-422e-9cbf-c49bad387b27


