### PR TITLE
Amberroseweeks/426-property-table-feat-505-priority-badge

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -142,6 +142,13 @@
     @apply underline text-blue hover:text-blue-800 visited:text-purple-600;
   }
 
+  table {
+    border-collapse: collapse;
+    border-radius: 6px;
+    border-style: hidden; /* hide standard table (collapsed) border */
+    box-shadow: 0 0 0 1px #ccdce3; /* this draws the table border  */
+  }
+
   /* added webkit transform to remove icon movement in safari */
 
   .iconLink {
@@ -190,7 +197,7 @@
 }
 
 .table-cell {
-  @apply p-2 border border-gray-300 text-left font-normal;
+  @apply p-2 border border-gray-200 rounded-md text-left font-normal;
 }
 
 .link {

--- a/src/components/SinglePropertyDetail.tsx
+++ b/src/components/SinglePropertyDetail.tsx
@@ -1,6 +1,8 @@
 import { MapGeoJSONFeature } from "maplibre-gl";
 import Image from "next/image";
 import { Chip } from "@nextui-org/react";
+import { Check, Info } from "@phosphor-icons/react";
+import { Button, Tooltip } from "@nextui-org/react";
 import {
   ArrowSquareOut,
   ArrowLeft,
@@ -181,12 +183,6 @@ const SinglePropertyDetail = ({
             <td className="table-cell">
               <p>{owner_1}</p>
               {owner_2 && <p>{owner_2}</p>}
-            </td>
-          </tr>
-          <tr>
-            <Th>Parcel Type</Th>
-            <td className="table-cell">
-              <p>{parcel_type}</p>
             </td>
           </tr>
           <tr>

--- a/src/components/SinglePropertyDetail.tsx
+++ b/src/components/SinglePropertyDetail.tsx
@@ -1,5 +1,6 @@
 import { MapGeoJSONFeature } from "maplibre-gl";
 import Image from "next/image";
+import { Chip } from "@nextui-org/react";
 import {
   ArrowSquareOut,
   ArrowLeft,
@@ -21,6 +22,19 @@ interface PropertyDetailProps {
   setSelectedProperty: (property: MapGeoJSONFeature | null) => void;
   setIsStreetViewModalOpen: Dispatch<SetStateAction<boolean>>;
   updateCurrentView: (view: BarClickOptions) => void;
+}
+
+function getPriorityClass(priorityLevel: string) {
+  switch (priorityLevel) {
+    case "High":
+      return "bg-red-200 text-red-800"; // Style for High Priority
+    case "Medium":
+      return "bg-yellow-200 text-yellow-800"; // Style for Medium Priority
+    case "Low":
+      return "bg-green-200 text-green-800"; // Style for Low Priority
+    default:
+      return "bg-gray-500 border-gray-700"; // Default style
+  }
 }
 
 const SinglePropertyDetail = ({
@@ -52,9 +66,10 @@ const SinglePropertyDetail = ({
   } = properties;
   const image = `https://storage.googleapis.com/cleanandgreenphl/${OPA_ID}.jpg`;
   const atlasUrl = `https://atlas.phila.gov/${address}`;
+  const priorityClass = getPriorityClass(priority_level);
 
   const priorityBgClassName = priority_level.includes("High")
-    ? "bg-priority-high"
+    ? "bg-red-200 text-red-800"
     : priority_level.includes("Medium")
     ? "bg-priority-medium"
     : priority_level.includes("Low")
@@ -133,10 +148,14 @@ const SinglePropertyDetail = ({
             <Th>Suggested Priority</Th>
             <td className="table-cell">
               <div className="flex gap-1 items-center">
-                <span
-                  className={`inline-block w-4 h-4 ${priorityBgClassName}`}
-                />
-                {priority_level}
+                <Chip
+                  classNames={{
+                    base: `${priorityClass} border-small border-white/50`,
+                    content: "body-sm",
+                  }}
+                >
+                  {priority_level + " Priority"}
+                </Chip>
               </div>
             </td>
           </tr>
@@ -153,7 +172,7 @@ const SinglePropertyDetail = ({
 
       <table aria-label="Land Information" className="w-full mb-4">
         <tbody>
-          <tr style={{ display: "none" }}>
+          <tr>
             <Th>Access Process</Th>
             <td className="table-cell">{access_process}</td>
           </tr>


### PR DESCRIPTION
This closes issue https://github.com/CodeForPhilly/vacant-lots-proj/issues/426 and https://github.com/CodeForPhilly/vacant-lots-proj/issues/505

Updated table content per Figma design, note that the links and tooltips within the design are not included. I also update the table style to match the figma design as well (border color and border radius)

https://www.figma.com/proto/NAFkgq34abW6uJ0R7PW24T/Prototype---Clean-%26-Green-Philly?page-id=187%3A12602&type=design&node-id=2592-30687&viewport=-657%2C-623%2C0.1&t=fqZvOvLyE9qv7AAV-8&scaling=min-zoom&starting-point-node-id=2592%3A30019&hide-ui=1

<img width="669" alt="Screen Shot 2024-04-16 at 8 47 30 PM" src="https://github.com/CodeForPhilly/vacant-lots-proj/assets/61482332/0cd39b13-c483-49d9-acdf-c31f0904d624">

**Note** I don't think we have L&I details as part of the data, I would like to check in with @brandonfcohen1 about this but I also want to get the simple updates shared. 

Right now, the L&I violations are totaled and shared as a number but in the Figma they are a list with a description and date. Is this data available and what parameters do we need to call to access it? I was not able to determine if this is in the database myself. 

<img width="1054" alt="figma preview on left and local branch on right" src="https://github.com/CodeForPhilly/vacant-lots-proj/assets/61482332/f82c086a-35d8-41de-a784-3e92b7e39f89">


