### PR TITLE
Fix #506: Updated filter info 

### DIFF
--- a/src/app/(content-pages)/methodology/MethodologyPage.tsx
+++ b/src/app/(content-pages)/methodology/MethodologyPage.tsx
@@ -1,6 +1,3 @@
-import Image from "next/image";
-import imageKde from "@/images/kde_map.png";
-
 export default function MethodologyPage() {
   return (
     <div className="flex flex-col min-h-screen">
@@ -33,7 +30,8 @@ export default function MethodologyPage() {
               community residents, CDCs, City government offices, academic
               researchers, and more.
             </p>
-
+            {/* Offset for clicking on learn more from filter, scrolls to section below */}
+            <span id="priority-method"></span>
             <p className="body-md">
               Although we aim to simplify the decision-making process for users
               of Clean & Green Philly, we value transparency. Below, we lay out
@@ -112,6 +110,8 @@ export default function MethodologyPage() {
                 </li>
               </ol>
               <br />
+              {/* Offset for clicking on learn more from filter, scrolls to section below */}
+              <span id="access-method"></span>
               <p className="body-md mb-4">
                 These specific datasets were chosen based on the original
                 research and extensive stakeholder engagement. The decision tree

--- a/src/components/FilterView.tsx
+++ b/src/components/FilterView.tsx
@@ -9,16 +9,9 @@ import { rcos, neighborhoods } from "./Filters/FilterOptions";
 const filters = [
   {
     property: "priority_level",
-    display: "Priority Level",
+    display: "Suggested Priority",
     options: ["Low", "Medium", "High"],
     tooltip: "For information on how this is calculated, see the About page",
-    type: "buttonGroup",
-  },
-  {
-    property: "parcel_type",
-    display: "Parcel Type",
-    options: ["Land", "Building"],
-    tooltip: "Parcel type from City of Philadelphia data",
     type: "buttonGroup",
   },
   {
@@ -41,6 +34,13 @@ const filters = [
     options: rcos,
     tooltip: "RCO mapping from City of Philadelphia data",
     type: "multiSelect",
+  },
+  {
+    property: "parcel_type",
+    display: "Parcel Type",
+    options: ["Land", "Building"],
+    tooltip: "Parcel type from City of Philadelphia data",
+    type: "buttonGroup",
   },
   {
     property: "tactical_urbanism",

--- a/src/components/FilterView.tsx
+++ b/src/components/FilterView.tsx
@@ -5,69 +5,59 @@ import { BarClickOptions } from "@/app/find-properties/[[...opa_id]]/page";
 import { ThemeButton } from "./ThemeButton";
 import { rcos, neighborhoods } from "./Filters/FilterOptions";
 
-
 const filters = [
   {
     property: "priority_level",
     display: "Suggested Priority",
     options: ["Low", "Medium", "High"],
-    tooltip: "For information on how this is calculated, see the About page",
     type: "buttonGroup",
   },
   {
     property: "access_process",
     display: "Access Process",
     options: ["Buy Property", "Land Bank", "Private Land Use Agreement"],
-    tooltip: "For information on what these mean, see the Get Access page",
     type: "buttonGroup",
   },
   {
     property: "neighborhood",
     display: "Neighborhoods",
     options: neighborhoods,
-    tooltip: "Neighborhood mapping from OpenDataPhilly by Element 84 (formerly Azavea)",
     type: "multiSelect",
   },
   {
     property: "rco_names",
     display: "Community Organizations",
     options: rcos,
-    tooltip: "RCO mapping from City of Philadelphia data",
     type: "multiSelect",
   },
   {
     property: "parcel_type",
     display: "Parcel Type",
     options: ["Land", "Building"],
-    tooltip: "Parcel type from City of Philadelphia data",
     type: "buttonGroup",
   },
   {
     property: "tactical_urbanism",
     display: "Tactical Urbanism",
     options: ["Yes", "No"],
-    tooltip: "For an explanation of this, see the Get Access page",
     type: "buttonGroup",
   },
   {
     property: "conservatorship",
     display: "Conservatorship Eligible",
     options: ["Yes", "No"],
-    tooltip: "For an explanation of this, see the Get Access page",
     type: "buttonGroup",
   },
   {
     property: "side_yard_eligible",
     display: "Side Yard Eligible",
     options: ["Yes", "No"],
-    tooltip: "For an explanation of this, see the Get Access page",
     type: "buttonGroup",
   },
   {
     property: "llc_owner",
     display: "LLC Owner",
     options: ["Yes", "No"],
-    tooltip: "For an explanation of this, see the Get Access page",
     type: "buttonGroup",
   },
 ];
@@ -86,15 +76,8 @@ const FilterView: FC<FilterViewProps> = ({ updateCurrentView }) => {
         startContent={<PiX />}
         onPress={() => updateCurrentView("filter")}
       />
-      {filters.map(({ property, display, options, tooltip, type }) => (
-        <DimensionFilter
-          key={property}
-          property={property}
-          options={options}
-          display={display}
-          tooltip={tooltip}
-          type={type}
-        />
+      {filters.map((attr) => (
+        <DimensionFilter key={attr.property} {...attr} />
       ))}
     </div>
   );

--- a/src/components/FilterView.tsx
+++ b/src/components/FilterView.tsx
@@ -62,11 +62,13 @@ const filters = [
   },
 ];
 
-type FilterViewProps = {
+interface FilterViewProps {
   updateCurrentView: (view: BarClickOptions) => void;
 };
 
+
 const FilterView: FC<FilterViewProps> = ({ updateCurrentView }) => {
+
   return (
     <div className="relative p-6">
       <ThemeButton

--- a/src/components/FilterView.tsx
+++ b/src/components/FilterView.tsx
@@ -64,11 +64,9 @@ const filters = [
 
 interface FilterViewProps {
   updateCurrentView: (view: BarClickOptions) => void;
-};
-
+}
 
 const FilterView: FC<FilterViewProps> = ({ updateCurrentView }) => {
-
   return (
     <div className="relative p-6">
       <ThemeButton

--- a/src/components/Filters/ButtonGroup.tsx
+++ b/src/components/Filters/ButtonGroup.tsx
@@ -18,7 +18,7 @@ const ButtonGroup: FC<ButtonGroupProps> = ({
 }) => {
 
     return (
-        <div className="space-x-2 min-h-[33.5px]">
+        <div className="flex flex-wrap gap-x-2 min-h-[33.5px]">
             {options.map((option, index) => (
                 <Button
                     key={index}
@@ -27,7 +27,9 @@ const ButtonGroup: FC<ButtonGroupProps> = ({
                     size="sm"
                     color={selectedKeys.includes(option) ? "success" : "default"}
                     className={
-                        selectedKeys.includes(option) ? "tagSelected" : "tagDefault"
+                        (selectedKeys.includes(option) ? "tagSelected" : "tagDefault")
+                        + 
+                        (option === "Private Land Use Agreement" ? " max-[475px]:mt-2 sm:max-[1103px]:mt-2" : "")
                     }
                     radius="full"
                     aria-pressed={selectedKeys.includes(option)}

--- a/src/components/Filters/ButtonGroup.tsx
+++ b/src/components/Filters/ButtonGroup.tsx
@@ -4,46 +4,45 @@ import React, { FC } from "react";
 import { Button } from "@nextui-org/react";
 import { Check } from "@phosphor-icons/react";
 
-
 type ButtonGroupProps = {
-    options: string[];
-    selectedKeys: string[];
-    toggleDimension: (dimension: string) => void;
-}
+  options: string[];
+  selectedKeys: string[];
+  toggleDimension: (dimension: string) => void;
+};
 
 const ButtonGroup: FC<ButtonGroupProps> = ({
-    options,
-    selectedKeys,
-    toggleDimension,
+  options,
+  selectedKeys,
+  toggleDimension,
 }) => {
+  return (
+    <div className="flex flex-wrap gap-x-2 min-h-[33.5px]">
+      {options.map((option, index) => (
+        <Button
+          key={index}
+          disableAnimation
+          onPress={() => toggleDimension(option)}
+          size="sm"
+          color={selectedKeys.includes(option) ? "success" : "default"}
+          className={
+            (selectedKeys.includes(option) ? "tagSelected" : "tagDefault") +
+            (option === "Private Land Use Agreement"
+              ? " max-[475px]:mt-2 sm:max-[1103px]:mt-2"
+              : "")
+          }
+          radius="full"
+          aria-pressed={selectedKeys.includes(option)}
+          startContent={
+            selectedKeys.includes(option) ? (
+              <Check className="w-3 w-3.5 max-h-6" />
+            ) : undefined
+          }
+        >
+          {option}
+        </Button>
+      ))}
+    </div>
+  );
+};
 
-    return (
-        <div className="flex flex-wrap gap-x-2 min-h-[33.5px]">
-            {options.map((option, index) => (
-                <Button
-                    key={index}
-                    disableAnimation
-                    onPress={() => toggleDimension(option)}
-                    size="sm"
-                    color={selectedKeys.includes(option) ? "success" : "default"}
-                    className={
-                        (selectedKeys.includes(option) ? "tagSelected" : "tagDefault")
-                        + 
-                        (option === "Private Land Use Agreement" ? " max-[475px]:mt-2 sm:max-[1103px]:mt-2" : "")
-                    }
-                    radius="full"
-                    aria-pressed={selectedKeys.includes(option)}
-                    startContent={
-                        selectedKeys.includes(option) ? (
-                        <Check className="w-3 w-3.5 max-h-6" />
-                        ) : undefined
-                    }
-                >
-                    {option}
-                </Button>
-            ))}
-        </div>
-    )
-}
-
-export default ButtonGroup
+export default ButtonGroup;

--- a/src/components/Filters/DimensionFilter.tsx
+++ b/src/components/Filters/DimensionFilter.tsx
@@ -25,8 +25,8 @@ const DimensionFilter: FC<DimensionFilterProps> = ({
 
   const toggleDimension = (dimension: string) => {
     const newSelectedKeys = selectedKeys.includes(dimension)
-    ? selectedKeys.filter(key => key !== dimension)
-    : [...selectedKeys, dimension];
+      ? selectedKeys.filter((key) => key !== dimension)
+      : [...selectedKeys, dimension];
     setSelectedKeys(newSelectedKeys);
     dispatch({
       type: "SET_DIMENSIONS",
@@ -34,43 +34,66 @@ const DimensionFilter: FC<DimensionFilterProps> = ({
       dimensions: newSelectedKeys,
     });
   };
-  
+
   const handleSelectionChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const newMultiSelect: string[] = e.target.value.split(",")
+    const newMultiSelect: string[] = e.target.value.split(",");
     setSelectedKeys(newMultiSelect);
     dispatch({
       type: "SET_DIMENSIONS",
       property,
       dimensions: newMultiSelect,
     });
-  }
+  };
 
   const filter = () => {
     if (type === "buttonGroup") {
       return (
-        <ButtonGroup 
-          options={options} 
-          selectedKeys={selectedKeys} 
-          toggleDimension={toggleDimension} 
-        /> 
-      )
+        <ButtonGroup
+          options={options}
+          selectedKeys={selectedKeys}
+          toggleDimension={toggleDimension}
+        />
+      );
     } else {
       return (
-        <MultiSelect 
-          display={display} 
-          options={options} 
-          selectedKeys={selectedKeys} 
-          toggleDimension={toggleDimension} 
+        <MultiSelect
+          display={display}
+          options={options}
+          selectedKeys={selectedKeys}
+          toggleDimension={toggleDimension}
           handleSelectionChange={handleSelectionChange}
         />
-      )
+      );
     }
-  }
+  };
 
+  const filterDescription =
+    property === "priority_level"
+      ? {
+          desc: "Find properties based on how much they can reduce gun violence considering the gun violence, cleanliness, and tree canopy nearby. ",
+          linkFragment: "priority-method",
+        }
+      : {
+          desc: "Find properties based on what we think is the easiest method to get legal access to them, based on the data available to us. ",
+          linkFragment: "access-method",
+        };
+  // text-gray-500, 600 ? or #586266 (figma)?
   return (
-    <div className="pb-6">
-      <div className="flex items-center mb-2">
+    <div className="pt-3 pb-6">
+      <div className="flex flex-col mb-2">
         <h2 className="heading-lg">{display}</h2>
+        {(property === "access_process" || property === "priority_level") && (
+          <p className="body-sm text-gray-500 w-[90%] my-1">
+            {filterDescription.desc}
+            <a
+              href={`/methodology/#${filterDescription.linkFragment}`}
+              className="link"
+              aria-label={`Goes to methodology page for ${property}`}
+            >
+              Learn more{" "}
+            </a>
+          </p>
+        )}
       </div>
       {filter()}
     </div>

--- a/src/components/Filters/DimensionFilter.tsx
+++ b/src/components/Filters/DimensionFilter.tsx
@@ -74,16 +74,7 @@ const DimensionFilter: FC<DimensionFilterProps> = ({
   return (
     <div className="pb-6">
       <div className="flex items-center mb-2">
-        <div className="flex items-center">
-          <h2 className="heading-lg">{display}</h2>
-          <Tooltip content={tooltip} placement="top" showArrow color="primary">
-            <Info
-              alt="More Info"
-              className="h-5 w-9 text-gray-500 pl-2 pr-2 cursor-pointer"
-              tabIndex={0}
-            />
-          </Tooltip>
-        </div>
+        <h2 className="heading-lg">{display}</h2>
       </div>
       {filter()}
     </div>

--- a/src/components/Filters/DimensionFilter.tsx
+++ b/src/components/Filters/DimensionFilter.tsx
@@ -1,9 +1,7 @@
 "use client";
 
 import React, { useState, FC } from "react";
-import { Tooltip } from "@nextui-org/react";
 import { useFilter } from "@/context/FilterContext";
-import { Info } from "@phosphor-icons/react";
 import ButtonGroup from "./ButtonGroup";
 import MultiSelect from "./MultiSelect";
 
@@ -11,7 +9,6 @@ type DimensionFilterProps = {
   property: string;
   display: string;
   options: string[];
-  tooltip: string;
   type: string;
 };
 
@@ -19,7 +16,6 @@ const DimensionFilter: FC<DimensionFilterProps> = ({
   property,
   display,
   options,
-  tooltip,
   type,
 }) => {
   const { dispatch, appFilter } = useFilter();


### PR DESCRIPTION
## Description
This PR addresses issue #506 which includes:
- Removing icons next to headers
- Rearranging order of the filters
- Adding descriptions for suggested priority and access level
- Clicking on learn more scrolls to respective sections

I also corrected the alignment of the access process filters when they overflow.

## Testing/Proof
### General & clicking on learn more

https://github.com/CodeForPhilly/vacant-lots-proj/assets/28910543/4bc69320-2da1-463d-b876-09267c1c4ebd


### Access process filters corrected alignment


https://github.com/CodeForPhilly/vacant-lots-proj/assets/28910543/7dd29e9c-5f12-46ba-967b-d312d92e2689




