### PR TITLE
486: Map behavior after property search

### DIFF
--- a/src/app/find-properties/[[...opa_id]]/page.tsx
+++ b/src/app/find-properties/[[...opa_id]]/page.tsx
@@ -214,6 +214,7 @@ const MapPage = ({ params }: MapPageProps) => {
               </div>
               {isLinkedPropertyParsed ? (
                 <PropertyMap
+                  featuresInView={featuresInView}
                   setFeaturesInView={setFeaturesInView}
                   setLoading={setLoading}
                   selectedProperty={selectedProperty}

--- a/src/components/PropertyMap.tsx
+++ b/src/components/PropertyMap.tsx
@@ -49,6 +49,11 @@ import { Info } from "@phosphor-icons/react";
 import { centroid } from "@turf/centroid";
 import { Position } from "geojson";
 
+type SearchedProperty = {
+  coordinates: [number, number],
+  address: string,
+};
+
 const MIN_MAP_ZOOM = 10;
 const MAX_MAP_ZOOM = 20;
 const MAX_TILE_ZOOM = 16;
@@ -112,6 +117,7 @@ const MapControls = () => (
 );
 
 interface PropertyMapProps {
+  featuresInView: MapGeoJSONFeature[];
   setFeaturesInView: Dispatch<SetStateAction<any[]>>;
   setLoading: Dispatch<SetStateAction<boolean>>;
   selectedProperty: MapGeoJSONFeature | null;
@@ -122,6 +128,7 @@ interface PropertyMapProps {
   setPrevCoordinate: () => void;
 }
 const PropertyMap: FC<PropertyMapProps> = ({
+  featuresInView,
   setFeaturesInView,
   setLoading,
   selectedProperty,
@@ -135,6 +142,7 @@ const PropertyMap: FC<PropertyMapProps> = ({
   const [popupInfo, setPopupInfo] = useState<any | null>(null);
   const [map, setMap] = useState<MaplibreMap | null>(null);
   const geocoderRef = useRef<MapboxGeocoder | null>(null);
+  const [searchedProperty, setSearchedProperty] = useState<SearchedProperty>({coordinates: [-75.1628565788269, 39.97008211622267], address: ''});
 
   useEffect(() => {
     let protocol = new Protocol();
@@ -187,9 +195,9 @@ const PropertyMap: FC<PropertyMapProps> = ({
     }
   };
 
-  const handleMapClick = (coordinates: LngLat | [number, number], address: string = '') => {
+  const handleMapClick = (clickPoint: LngLat) => {
     if (map) {
-      const features = map.queryRenderedFeatures(map.project(coordinates), {
+      const features = map.queryRenderedFeatures(map.project(clickPoint), {
         layers,
       });
 
@@ -197,18 +205,9 @@ const PropertyMap: FC<PropertyMapProps> = ({
         setSelectedProperty(features[0]);
       } else {
         setSelectedProperty(null);
-        if (coordinates instanceof LngLat) {
-          setPopupInfo(null);
-        } else {
-          setPopupInfo({
-            longitude: coordinates[0],
-            latitude: coordinates[1],
-            feature: {address: address},
-          });
-        }
-        }
       }
-    };
+    }
+  };
 
   const handleSetFeatures = (event: any) => {
     if (!["moveend", "sourcedata"].includes(event.type)) return;
@@ -255,6 +254,28 @@ const PropertyMap: FC<PropertyMapProps> = ({
   };
 
   useEffect(() => {
+    // This useEffect sets selectedProperty and map popup information after a property has been searched in the map's search form
+    if (!featuresInView || selectedProperty || searchedProperty.address === '') return;
+
+    if (map) {
+      const features = map.queryRenderedFeatures(map.project(searchedProperty.coordinates), {
+        layers,
+      });
+      if (features.length > 0) {
+        setSelectedProperty(features[0])
+        setSearchedProperty({...searchedProperty, address: ''})
+      } else {
+        setSelectedProperty(null);
+        setPopupInfo({
+          longitude: searchedProperty.coordinates[0],
+          latitude: searchedProperty.coordinates[1],
+          feature: {address: searchedProperty.address},
+        });
+      }
+    }
+  }, [featuresInView, selectedProperty])
+
+  useEffect(() => {
     if (map) {
       // Add info icon to legend on map load
       const legendSummary = document.getElementById("legend-summary");
@@ -299,10 +320,14 @@ const PropertyMap: FC<PropertyMapProps> = ({
 
         geocoderRef.current.on("result", (e) => {
           const address = e.result.place_name.split(',')[0]
+          setSelectedProperty(null)
+          setSearchedProperty({
+            coordinates: e.result.center,
+            address: address
+          })
           map.easeTo({
             center: e.result.center,
           });
-          setTimeout(handleMapClick, 500, e.result.center, address)
         });
       }
     }

--- a/src/components/PropertyMap.tsx
+++ b/src/components/PropertyMap.tsx
@@ -197,9 +197,28 @@ const PropertyMap: FC<PropertyMapProps> = ({
         setSelectedProperty(features[0]);
       } else {
         setSelectedProperty(null);
+        setPopupInfo(null);
+        }
+      }
+    };
+    
+    const handleMapSearch = (coordinates: [number, number], address: string) => {
+      if (map) {
+        const features = map.queryRenderedFeatures(map.project(coordinates), {
+          layers,
+        });
+        if (features.length > 0) {
+          setSelectedProperty(features[0]);
+        } else {
+          setSelectedProperty(null)
+          setPopupInfo({
+            longitude: coordinates[0],
+            latitude: coordinates[1],
+            feature: {address: address},
+          });
+        }
       }
     }
-  };
 
   const handleSetFeatures = (event: any) => {
     if (!["moveend", "sourcedata"].includes(event.type)) return;
@@ -289,10 +308,9 @@ const PropertyMap: FC<PropertyMapProps> = ({
         map.addControl(geocoderRef.current as unknown as IControl, "top-right");
 
         geocoderRef.current.on("result", (e) => {
-          map.easeTo({
-            center: e.result.center,
-            zoom: MAX_TILE_ZOOM,
-          });
+          const coordinates: [number, number] = e.result.center
+          const address = e.result.place_name.split(',')[0]
+          handleMapSearch(coordinates, address)
         });
       }
     }
@@ -309,7 +327,7 @@ const PropertyMap: FC<PropertyMapProps> = ({
   useEffect(() => {
     if (!map) return;
     if (!selectedProperty) {
-      setPopupInfo(null);
+      // setPopupInfo(null);
       if (window.innerWidth < 640 && prevCoordinate) {
         map.setCenter(prevCoordinate as LngLatLike);
         setPrevCoordinate();

--- a/src/components/PropertyMap.tsx
+++ b/src/components/PropertyMap.tsx
@@ -207,6 +207,7 @@ const PropertyMap: FC<PropertyMapProps> = ({
       const features = map.queryRenderedFeatures(map.project(coordinates), {
         layers,
       });
+
       if (features.length > 0) {
         setSelectedProperty(features[0]);
       } else {
@@ -312,7 +313,7 @@ const PropertyMap: FC<PropertyMapProps> = ({
           map.easeTo({
             center: e.result.center,
           });
-          handleMapSearch(e.result.center, address)
+          setTimeout(handleMapSearch, 500, e.result.center, address)
         });
       }
     }

--- a/src/components/PropertyMap.tsx
+++ b/src/components/PropertyMap.tsx
@@ -201,24 +201,24 @@ const PropertyMap: FC<PropertyMapProps> = ({
         }
       }
     };
-    
-    const handleMapSearch = (coordinates: [number, number], address: string) => {
-      if (map) {
-        const features = map.queryRenderedFeatures(map.project(coordinates), {
-          layers,
+
+  const handleMapSearch = (coordinates: [number, number], address: string) => {
+    if (map) {
+      const features = map.queryRenderedFeatures(map.project(coordinates), {
+        layers,
+      });
+      if (features.length > 0) {
+        setSelectedProperty(features[0]);
+      } else {
+        setSelectedProperty(null)
+        setPopupInfo({
+          longitude: coordinates[0],
+          latitude: coordinates[1],
+          feature: {address: address},
         });
-        if (features.length > 0) {
-          setSelectedProperty(features[0]);
-        } else {
-          setSelectedProperty(null)
-          setPopupInfo({
-            longitude: coordinates[0],
-            latitude: coordinates[1],
-            feature: {address: address},
-          });
-        }
       }
     }
+  }
 
   const handleSetFeatures = (event: any) => {
     if (!["moveend", "sourcedata"].includes(event.type)) return;
@@ -308,9 +308,11 @@ const PropertyMap: FC<PropertyMapProps> = ({
         map.addControl(geocoderRef.current as unknown as IControl, "top-right");
 
         geocoderRef.current.on("result", (e) => {
-          const coordinates: [number, number] = e.result.center
           const address = e.result.place_name.split(',')[0]
-          handleMapSearch(coordinates, address)
+          map.easeTo({
+            center: e.result.center,
+          });
+          handleMapSearch(e.result.center, address)
         });
       }
     }

--- a/src/components/PropertyMap.tsx
+++ b/src/components/PropertyMap.tsx
@@ -187,22 +187,7 @@ const PropertyMap: FC<PropertyMapProps> = ({
     }
   };
 
-  const handleMapClick = (clickPoint: LngLat) => {
-    if (map) {
-      const features = map.queryRenderedFeatures(map.project(clickPoint), {
-        layers,
-      });
-
-      if (features.length > 0) {
-        setSelectedProperty(features[0]);
-      } else {
-        setSelectedProperty(null);
-        setPopupInfo(null);
-        }
-      }
-    };
-
-  const handleMapSearch = (coordinates: [number, number], address: string) => {
+  const handleMapClick = (coordinates: LngLat | [number, number], address: string = '') => {
     if (map) {
       const features = map.queryRenderedFeatures(map.project(coordinates), {
         layers,
@@ -211,15 +196,19 @@ const PropertyMap: FC<PropertyMapProps> = ({
       if (features.length > 0) {
         setSelectedProperty(features[0]);
       } else {
-        setSelectedProperty(null)
-        setPopupInfo({
-          longitude: coordinates[0],
-          latitude: coordinates[1],
-          feature: {address: address},
-        });
+        setSelectedProperty(null);
+        if (coordinates instanceof LngLat) {
+          setPopupInfo(null);
+        } else {
+          setPopupInfo({
+            longitude: coordinates[0],
+            latitude: coordinates[1],
+            feature: {address: address},
+          });
+        }
+        }
       }
-    }
-  }
+    };
 
   const handleSetFeatures = (event: any) => {
     if (!["moveend", "sourcedata"].includes(event.type)) return;
@@ -313,7 +302,7 @@ const PropertyMap: FC<PropertyMapProps> = ({
           map.easeTo({
             center: e.result.center,
           });
-          setTimeout(handleMapSearch, 500, e.result.center, address)
+          setTimeout(handleMapClick, 500, e.result.center, address)
         });
       }
     }


### PR DESCRIPTION
This addresses issue #486 

When a user searches for a property in the map's search bar, the map shifts to the property and a tooltip appears marking the property.

If the searched-for property is vacant, the side panel changes to the property details.  If the property is not vacant, the side panel remains in the list view or (if it was previously showing another property's details) returns to the list view.

@thansidwell - I don't see any details about whether a zoom level should be set for the search result, so as of now the zoom level does not change when a property is searched.

Also, I thought I saw an assigned ticket that was handling the styling of the map tooltip.  I can't find it now and don't see changes on staging site, so if I was imagining that please let me know and I'll work on the tooltip styling.

@paulhchoi and @brandonfcohen1 - For properties that are out of view when they are searched, I had some trouble checking whether they are in the dataset of vacant properties .  My solution was to delay calling the 'handleMapClick' function (which I'm re-purposing for the search) with a setTimeout() with a 0.5 second delay.  I don't know if that's best practice, or enough time/too little time, but I couldn't get it to work otherwise.