### PR TITLE
205-header-semantics-and-removing-extra-tooltip-import

### DIFF
--- a/src/components/SinglePropertyDetail.tsx
+++ b/src/components/SinglePropertyDetail.tsx
@@ -19,7 +19,6 @@ import SinglePropertyInfoCard from "./SinglePropertyInfoCard";
 import { Dispatch, SetStateAction, useState } from "react";
 import { BarClickOptions } from "@/app/find-properties/[[...opa_id]]/page";
 import { ThemeButton, ThemeButtonLink } from "./ThemeButton";
-import { Tooltip } from "@nextui-org/react";
 
 interface PropertyDetailProps {
   property: MapGeoJSONFeature | null;


### PR DESCRIPTION
This closes issue https://github.com/CodeForPhilly/vacant-lots-proj/issues/205

I am resubmitting this PR and I also have removed the extra import for the tooltip component on line 22 "import { Tooltip } from "@nextui-org/react";" from SinglePropertyDetail.tsx

This resolves errors on my local machine, please let me know @brandonfcohen1 if there are any other errors