### PR TITLE
fix(507): fix "Get Property Access" options logic

### DIFF
--- a/src/components/PropertyAccessOptionContainer.tsx
+++ b/src/components/PropertyAccessOptionContainer.tsx
@@ -9,19 +9,12 @@ const determineCardEnums = (property: any) => {
 
   if (property.access_process === "Private Land Use Agreement") {
     best = PropertyAccess.PRIVATE_LAND_USE;
-    available.add(PropertyAccess.BUY_FROM_OWNER);
   }
 
   if (property.access_process === "Buy Property") {
     best = PropertyAccess.BUY_FROM_OWNER;
     available.add(PropertyAccess.PRIVATE_LAND_USE);
-  }
-
-  if (
-    !available.has(PropertyAccess.BUY_FROM_OWNER) &&
-    best !== PropertyAccess.BUY_FROM_OWNER &&
-    property.market_value <= 1000
-  ) {
+  } else if (property.market_value <= 1000) {
     available.add(PropertyAccess.BUY_FROM_OWNER);
   } else {
     unavailable.add(PropertyAccess.BUY_FROM_OWNER);


### PR DESCRIPTION
## Description

This PR adds a fix to the logic introduced in https://github.com/CodeForPhilly/vacant-lots-proj/pull/538

## Test

You can test this by selecting filters of the properties, and seeing that the properties returned have matching information

## Demo

https://github.com/CodeForPhilly/vacant-lots-proj/assets/8061917/330cf879-ac33-4b11-a784-ba969f89eb2a

