### PR TITLE
Add Gentrification Page Link to Transform Property Page

### DIFF
--- a/src/app/(content-pages)/transform-property/TransformPropertyPage.tsx
+++ b/src/app/(content-pages)/transform-property/TransformPropertyPage.tsx
@@ -403,9 +403,10 @@ export default function TransformPropertyPage() {
             that may inadvertently increase property values, increase rental
             prices and displace already-marginalized Philadelphians. We are
             working to avoid this by meeting extensively with community groups
-            and responding to their concerns.
-            {/* Read more about this topic. */}
-            {/* Link to gentrification page */}
+            and responding to their concerns.{" "}
+            <a href="/gentrification" className="link">
+              Read more about this topic.
+            </a>{" "}
           </p>
         </div>
       </div>


### PR DESCRIPTION
This adds the link to the Gentrification page to the Transform Property Page.

The link is at the bottom of the page with the text "Read more about this topic."