### PR TITLE
feat(536): add download button

### DIFF
--- a/src/components/SidePanelControlBar.tsx
+++ b/src/components/SidePanelControlBar.tsx
@@ -92,6 +92,7 @@ const SearchBarComponent: FC<SidePanelControlBarProps> = ({
             aria-label="Download"
             onPress={() => updateCurrentView("download")}
             startContent={<DownloadSimple />}
+            label={<span className="body-md max-lg:hidden">Download</span>}
             className={`max-md:min-w-[4rem] ${
               smallScreenMode === "map" ? "max-sm:hidden" : ""
             }`}


### PR DESCRIPTION
## Description

This PR adds a Download label to the detail pane button. Hides at the same breakpoint as the Filter button.

## Demo

https://github.com/CodeForPhilly/vacant-lots-proj/assets/8061917/03711965-3f26-47db-be90-e5c31e27e607

https://github.com/CodeForPhilly/vacant-lots-proj/issues/536
