### PR TITLE
Added "pointer-events: bounding-box" to maplibregl-ctrl-top-right

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -225,6 +225,7 @@
 #main .maplibregl-ctrl-top-right {
   top: 20px;
   right: 20px;
+  pointer-events: bounding-box;
 }
 
 /* Remove white background on menu item to display active page state */


### PR DESCRIPTION
This PR addresses a bug where you could not click into the map's search field.  It fixes the problem by adding `pointer-events: bounding-box' to globals.css in:
```
#main .maplibregl-ctrl-top-right {
  top: 20px;
  right: 20px;
  pointer-events: bounding-box;
}
```

This closes issue #582 