### PR TITLE
Bug Fix: Map Search Field Not Clickable

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -225,6 +225,7 @@
 #main .maplibregl-ctrl-top-right {
   top: 20px;
   right: 20px;
+  pointer-events: bounding-box;
 }
 
 /* Remove white background on menu item to display active page state */

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -196,6 +196,7 @@
 
 #main .maplibregl-ctrl-bottom-left {
   left: 20px;
+  pointer-events: bounding-box;
 }
 
 .link {

--- a/src/components/PropertyMap.tsx
+++ b/src/components/PropertyMap.tsx
@@ -174,6 +174,7 @@ const PropertyMap: FC<PropertyMapProps> = ({
         layers,
       });
 
+      setSearchedProperty({...searchedProperty, address: "" })
       if (features.length > 0) {
         setSelectedProperty(features[0]);
       } else {


### PR DESCRIPTION
This PR addresses two bugs where you could not click into the map's search field and you could not click the map tooltip. It fixes the bugs by adding `pointer-events: bounding-box' to globals.css for the classes for each of those features:
- maplibregl-ctrl-top-right
- maplibregl-ctrl-bottom-left

I've also added `setSearchedProperty({...searchedProperty, address: "" })` to the map `handleClick` function.  Without that, if the map is clicked on a non-vacant property, the map changes the popup tooltip to the last searched property.

This closes issue #582