### PR TITLE
561/ Fix Page Content Spacing

### DIFF
--- a/src/app/(content-pages)/about/AboutPage.tsx
+++ b/src/app/(content-pages)/about/AboutPage.tsx
@@ -10,7 +10,7 @@ export default function AboutPage() {
   return (
     <>
       <h1 className="heading-3xl font-bold mb-6">About This Project</h1>
-      <p className="body-lg mb-12">
+      <p className="body-lg mb-6">
         Philadelphia has a gun violence problem. Clean & Green Philly empowers
         Philadelphians to take action to solve it.
       </p>

--- a/src/app/(content-pages)/about/AboutPage.tsx
+++ b/src/app/(content-pages)/about/AboutPage.tsx
@@ -10,13 +10,13 @@ export default function AboutPage() {
   return (
     <>
       <h1 className="heading-3xl font-bold mb-6">About This Project</h1>
-      <p className="body-md mb-4">
+      <p className="body-lg mb-12">
         Philadelphia has a gun violence problem. Clean & Green Philly empowers
         Philadelphians to take action to solve it.
       </p>
       <br></br>
 
-      <div id={"problem"} className="my-20">
+      <div id={"problem"} className="mb-20">
         <InfoGraphicSection
           header={{ text: "The Gun Violence Problem" }}
           body={{

--- a/src/app/(content-pages)/transform-property/TransformPropertyPage.tsx
+++ b/src/app/(content-pages)/transform-property/TransformPropertyPage.tsx
@@ -25,7 +25,7 @@ export default function TransformPropertyPage() {
   return (
     <>
       <h1 className="heading-3xl font-bold mb-6">Transform a Property</h1>
-      <p className="body-lg">
+      <p className="body-lg mb-12">
         After gaining access to the property, you can transform a property to
         improve the quality of life in the neighborhood.
       </p>
@@ -37,7 +37,7 @@ export default function TransformPropertyPage() {
             "A Philadelphia lot before a clean up and the same lot, filled with trees and greenery after a clean up."
           }
           placeholder="blur"
-          className="w-full mt-6 overflow-hidden rounded-[20px] aspect-video md:aspect-auto object-cover object-center"
+          className="w-full overflow-hidden rounded-[20px] aspect-video md:aspect-auto object-cover object-center"
         />
       </div>
 


### PR DESCRIPTION
This changes makes the ticket's requested styling changes.

For the About page:
- Increases subheader text size to body-lg
- Decreases margin between image and subheader to 48px

For the Transform Property page:

- Increases margin between subheader and image to 48 px.
- does NOT change anything with margin above page header as that was done seperately