### PR TITLE
Fix #525: Fixed nav padding

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -13,55 +13,55 @@ import MobileNav from "./MobileNav";
 
 const Header = () => (
   <>
-  <MobileNav />
-  <Navbar maxWidth="full" position="sticky" height="auto" as="div" isBordered> 
-    <NavbarContent
-      as="div"
-      className="hidden min-[850px]:flex basis-1/5 sm:basis-full pl-8 py-4"
-      justify="start"
-    >
-      <NavbarBrand>
-        <Link href="/">
-          <Image
-            src="/logo.svg"
-            alt="Clean &amp; Green Philly Logo"
-            width={112}
-            height={67}
-          />
-        </Link>
-      </NavbarBrand>
-    </NavbarContent>
+    <MobileNav />
+    <Navbar className="px-1" maxWidth="full" position="sticky" height="auto" as="div" isBordered>
+      <NavbarContent
+        as="div"
+        className="hidden min-[850px]:flex basis-1/5 sm:basis-full py-4"
+        justify="start"
+      >
+        <NavbarBrand>
+          <Link href="/">
+            <Image
+              src="/logo.svg"
+              alt="Clean &amp; Green Philly Logo"
+              width={112}
+              height={67}
+            />
+          </Link>
+        </NavbarBrand>
+      </NavbarContent>
 
-    <NavbarContent
-      className="hidden min-[850px]:flex basis-1/5 sm:basis-full"
-      justify="end"
-      as="nav"
-      aria-label="primary"
-    >
-      <ul className="flex flex-row">
-        <IconLink
-          icon={<PiBinoculars className="h-6 w-6" />}
-          text="Find Properties"
-          href="/find-properties"
-        />
-        <IconLink
-          icon={<PiKey className="h-6 w-6" />}
-          text="Get Access"
-          href="/get-access"
-        />
-        <IconLink
-          icon={<PiTree className="h-6 w-6" />}
-          text="Transform"
-          href="/transform-property"
-        />
-        <IconLink
-          icon={<PiInfo className="h-6 w-6" />}
-          text="About"
-          href="/about"
-        />
-      </ul>
-    </NavbarContent>
-  </Navbar>
+      <NavbarContent
+        className="hidden min-[850px]:flex basis-1/5 sm:basis-full"
+        justify="end"
+        as="nav"
+        aria-label="primary"
+      >
+        <ul className="flex flex-row">
+          <IconLink
+            icon={<PiBinoculars className="h-6 w-6" />}
+            text="Find Properties"
+            href="/find-properties"
+          />
+          <IconLink
+            icon={<PiKey className="h-6 w-6" />}
+            text="Get Access"
+            href="/get-access"
+          />
+          <IconLink
+            icon={<PiTree className="h-6 w-6" />}
+            text="Transform"
+            href="/transform-property"
+          />
+          <IconLink
+            icon={<PiInfo className="h-6 w-6" />}
+            text="About"
+            href="/about"
+          />
+        </ul>
+      </NavbarContent>
+    </Navbar>
   </>
 );
 

--- a/src/components/MobileNav.tsx
+++ b/src/components/MobileNav.tsx
@@ -17,7 +17,7 @@ const MobileNav: FC = () => {
 
   return (
     <Navbar
-      className="min-[850px]:hidden h-24 px-3"
+      className="min-[850px]:hidden h-24 -mx-1"
       onMenuOpenChange={setIsMenuOpen}
       as="div"
       maxWidth="full"


### PR DESCRIPTION
## Description
This PR addresses issue #525.

I can't edit the padding (px-6) in the header element directly since it's part of the NextUI component. I used negative margins to get 20px in mobile and added 4px to get 28px in desktop.


## Testing/Proof


https://github.com/CodeForPhilly/vacant-lots-proj/assets/28910543/a39aa907-8401-4c20-a79a-a73ef4480c5f












