### PR TITLE
581 simplify get access filter

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -297,7 +297,7 @@ a .bg-color-none {
 }
 
 .panelDefault:hover {
-  @apply ease-in bg-gray-200;
+  @apply ease-out bg-gray-200;
 }
 
 .panelDefault:active {
@@ -309,7 +309,7 @@ a .bg-color-none {
 }
 
 .panelSelected:hover {
-  @apply ease-in bg-blue-300;
+  @apply ease-out bg-blue-300;
 }
 
 .panelSelected:active {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -292,6 +292,30 @@ a .bg-color-none {
   @apply bg-blue-300;
 }
 
+.panelDefault {
+  @apply flex flex-row items-center rounded-md p-3 space-x-3 bg-gray-100 text-gray-900;
+}
+
+.panelDefault:hover {
+  @apply ease-in bg-gray-200;
+}
+
+.panelDefault:active {
+  @apply ease-in bg-gray-300;
+}
+
+.panelSelected {
+  @apply flex flex-row items-center rounded-md p-3 space-x-3 bg-blue-200 text-blue-800;
+}
+
+.panelSelected:hover {
+  @apply ease-in bg-blue-300;
+}
+
+.panelSelected:active {
+  @apply ease-in bg-blue-400;
+}
+
 /* Centers the properties for small screens only, tailwind breakpoint */
 @media screen and (max-width: 639px) {
   .side-panel-container {

--- a/src/components/FilterView.tsx
+++ b/src/components/FilterView.tsx
@@ -4,7 +4,6 @@ import { PiX } from "react-icons/pi";
 import { BarClickOptions } from "@/app/find-properties/[[...opa_id]]/page";
 import { ThemeButton } from "./ThemeButton";
 import { rcos, neighborhoods, zoning } from "./Filters/filterOptions";
-import { access_options, PropertyAccess } from "@/config/propertyAccessOptions";
 
 
 const filters = [
@@ -15,11 +14,10 @@ const filters = [
     type: "buttonGroup",
   },
   {
-    // COMBINED FILTER
-    property: "access_process",
-    display: "Access Process",
-    options: ["Buy Property", "Land Bank", "Private Land Use Agreement"],
-    type: "buttonGroup",
+    property: "get_access",
+    display: "Get Access",
+    options: ["TACTICAL_URBANISM", "PRIVATE_LAND_USE", "BUY_FROM_OWNER", "SIDE_YARD", "LAND_BANK", "CONSERVATORSHIP"],
+    type: "panels",
   },
   {
     property: "neighborhood",
@@ -47,38 +45,10 @@ const filters = [
     type: "buttonGroup",
   },
   {
-    // COMBINED FILTER
-    property: "tactical_urbanism",
-    display: "Tactical Urbanism",
-    options: ["Yes", "No"],
-    type: "buttonGroup",
-  },
-  {
-    // COMBINED FILTER
-    property: "conservatorship",
-    display: "Conservatorship Eligible",
-    options: ["Yes", "No"],
-    type: "buttonGroup",
-  },
-  {
-    // COMBINED FILTER
-    property: "side_yard_eligible",
-    display: "Side Yard Eligible",
-    options: ["Yes", "No"],
-    type: "buttonGroup",
-  },
-  {
     property: "llc_owner",
     display: "LLC Owner",
     options: ["Yes", "No"],
     type: "buttonGroup",
-  },
-  {
-    // COMBINED FILTER --> "Get Permission from the Owner" (Private Land Use Agreement), "Buy Affordably from the Owner" (Buy Property), "Buy Through the Land Bank" (Land Bank)
-    property: "get_access",
-    display: "Get Access",
-    options: ["TACTICAL_URBANISM", "PRIVATE_LAND_USE", "BUY_FROM_OWNER", "SIDE_YARD", "LAND_BANK", "CONSERVATORSHIP"],
-    type: "panels",
   },
 ];
 

--- a/src/components/FilterView.tsx
+++ b/src/components/FilterView.tsx
@@ -4,6 +4,8 @@ import { PiX } from "react-icons/pi";
 import { BarClickOptions } from "@/app/find-properties/[[...opa_id]]/page";
 import { ThemeButton } from "./ThemeButton";
 import { rcos, neighborhoods, zoning } from "./Filters/filterOptions";
+import { access_options, PropertyAccess } from "@/config/propertyAccessOptions";
+
 
 const filters = [
   {
@@ -13,6 +15,7 @@ const filters = [
     type: "buttonGroup",
   },
   {
+    // COMBINED FILTER
     property: "access_process",
     display: "Access Process",
     options: ["Buy Property", "Land Bank", "Private Land Use Agreement"],
@@ -44,18 +47,21 @@ const filters = [
     type: "buttonGroup",
   },
   {
+    // COMBINED FILTER
     property: "tactical_urbanism",
     display: "Tactical Urbanism",
     options: ["Yes", "No"],
     type: "buttonGroup",
   },
   {
+    // COMBINED FILTER
     property: "conservatorship",
     display: "Conservatorship Eligible",
     options: ["Yes", "No"],
     type: "buttonGroup",
   },
   {
+    // COMBINED FILTER
     property: "side_yard_eligible",
     display: "Side Yard Eligible",
     options: ["Yes", "No"],
@@ -66,6 +72,13 @@ const filters = [
     display: "LLC Owner",
     options: ["Yes", "No"],
     type: "buttonGroup",
+  },
+  {
+    // COMBINED FILTER --> "Get Permission from the Owner" (Private Land Use Agreement), "Buy Affordably from the Owner" (Buy Property), "Buy Through the Land Bank" (Land Bank)
+    property: "get_access",
+    display: "Get Access",
+    options: ["TACTICAL_URBANISM", "PRIVATE_LAND_USE", "BUY_FROM_OWNER", "SIDE_YARD", "LAND_BANK", "CONSERVATORSHIP"],
+    type: "panels",
   },
 ];
 

--- a/src/components/Filters/DimensionFilter.tsx
+++ b/src/components/Filters/DimensionFilter.tsx
@@ -2,7 +2,6 @@
 
 import React, { useState, FC } from "react";
 import { useFilter } from "@/context/FilterContext";
-import { PropertyAccess } from "@/config/propertyAccessOptions";
 import ButtonGroup from "./ButtonGroup";
 import MultiSelect from "./MultiSelect";
 import Panels from "./Panels";
@@ -113,7 +112,7 @@ const DimensionFilter: FC<DimensionFilterProps> = ({
     <div className="pt-3 pb-6">
       <div className="flex flex-col mb-2">
         <h2 className="heading-lg">{display}</h2>
-        {(property === "access_process" || property === "priority_level") && (
+        {(property === "get_access" || property === "priority_level") && (
           <p className="body-sm text-gray-500 w-[90%] my-1">
             {filterDescription.desc}
             <a

--- a/src/components/Filters/DimensionFilter.tsx
+++ b/src/components/Filters/DimensionFilter.tsx
@@ -2,8 +2,10 @@
 
 import React, { useState, FC } from "react";
 import { useFilter } from "@/context/FilterContext";
+import { PropertyAccess } from "@/config/propertyAccessOptions";
 import ButtonGroup from "./ButtonGroup";
 import MultiSelect from "./MultiSelect";
+import Panels from "./Panels";
 
 type DimensionFilterProps = {
   property: string;
@@ -24,6 +26,24 @@ const DimensionFilter: FC<DimensionFilterProps> = ({
   const [selectedKeys, setSelectedKeys] = useState<string[]>(
     appFilter[property]?.values || []
   );
+  const [selectedPanelKeys, setSelectedPanelkeys] = useState<{[property: string]: string[]}>({})
+
+  const toggleDimensionForPanel = (dimension: string, panel_property: string) => {
+    let newSelectedPanelKeys
+    if (selectedPanelKeys[panel_property]) {
+      newSelectedPanelKeys = selectedPanelKeys[panel_property].includes(dimension)
+        ? selectedPanelKeys[panel_property].filter((key) => key !== dimension)
+        : [...selectedPanelKeys[panel_property], dimension];
+    } else {
+      newSelectedPanelKeys = [dimension]
+    }
+    setSelectedPanelkeys({...selectedPanelKeys, [panel_property]: newSelectedPanelKeys});
+    dispatch({
+      type: "SET_DIMENSIONS",
+      property: panel_property,
+      dimensions: newSelectedPanelKeys,
+    });
+  }
 
   const toggleDimension = (dimension: string) => {
     const newSelectedKeys = selectedKeys.includes(dimension)
@@ -57,6 +77,14 @@ const DimensionFilter: FC<DimensionFilterProps> = ({
           toggleDimension={toggleDimension}
         />
       );
+    } else if (type === "panels") {
+      return (
+        <Panels 
+          options={options}
+          selectedPanelKeys={selectedPanelKeys}
+          toggleDimensionForPanel={toggleDimensionForPanel}
+        />
+      )
     } else {
       return (
         <MultiSelect

--- a/src/components/Filters/Panels.tsx
+++ b/src/components/Filters/Panels.tsx
@@ -6,10 +6,61 @@ import { Check } from "@phosphor-icons/react";
 
 import { access_options, PropertyAccess, PropertyAccessOption } from "@/config/propertyAccessOptions";
 
+type PanelFilterOptions = PropertyAccessOption & {
+    alt_description: string;
+    dimension: string;
+    property: string;
+}
+
 type PanelsProps = {
     options: string[] | PropertyAccess[];
     selectedPanelKeys: {[property: string]: string[]};
     toggleDimensionForPanel: (dimension: string, property: string) => void;
+}
+
+const panel_access_options: Record<PropertyAccess | string, PanelFilterOptions> = {
+    [PropertyAccess.PRIVATE_LAND_USE]: {
+        ...access_options[PropertyAccess.PRIVATE_LAND_USE],
+        alt_description:
+        'Properties where you could get a "private land use agreement"',
+        dimension: 'Private Land Use Agreement',
+        property: 'access_process',
+    },
+    [PropertyAccess.TACTICAL_URBANISM]: {
+        ...access_options[PropertyAccess.TACTICAL_URBANISM],
+        alt_description:
+          'Properties likely safe to quickly clean without express permission',
+        dimension: 'Yes',
+        property: 'tactical_urbanism',
+      },
+      [PropertyAccess.BUY_FROM_OWNER]: {
+        ...access_options[PropertyAccess.BUY_FROM_OWNER],
+        alt_description:
+          'Properties with a market value under $1,000',
+        dimension: 'Buy Property',
+        property: 'access_process',
+      },
+      [PropertyAccess.SIDE_YARD]: {
+        ...access_options[PropertyAccess.SIDE_YARD],
+        alt_description:
+          'Properties eligible for the "Side Yard Program"',
+        dimension: 'Yes',
+        property: 'side_yard_eligible',
+      },
+      [PropertyAccess.LAND_BANK]: {
+        ...access_options[PropertyAccess.LAND_BANK],
+        alt_description:
+          'Properties available for discount prices from the Land Bank',
+        dimension: 'Land Bank',
+        property: 'access_process',
+      },
+      [PropertyAccess.CONSERVATORSHIP]: {
+        ...access_options[PropertyAccess.CONSERVATORSHIP],
+        alt_description:
+          'Abandoned and unsafe properties you can gain through a legal process',
+        dimension: 'Yes',
+        property: 'conservatorship',
+      },
 }
 
 const Panels: FC<PanelsProps> = ({
@@ -18,8 +69,8 @@ const Panels: FC<PanelsProps> = ({
     toggleDimensionForPanel,
 }) => {
 
-    const optionPanels = options.map((option) => {
-        const panel = access_options[option]
+    const optionPanels = options.map((option, index) => {
+        const panel = panel_access_options[option]
         const Icon = panel.icon;
         const panelStyle = () => {
             if (selectedPanelKeys[panel.property]) {
@@ -46,6 +97,7 @@ const Panels: FC<PanelsProps> = ({
 
         return (
             <Card
+                key={index}
                 className = { panelStyle() }
                 isPressable
                 onPress={() => toggleDimensionForPanel(panel.dimension, panel.property)}

--- a/src/components/Filters/Panels.tsx
+++ b/src/components/Filters/Panels.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { FC } from "react";
-import { Button, Card, Chip } from "@nextui-org/react";
+import { Button, Card, CardBody, Chip } from "@nextui-org/react";
 import { Check } from "@phosphor-icons/react";
 
 import { access_options, PropertyAccess, PropertyAccessOption } from "@/config/propertyAccessOptions";
@@ -21,32 +21,51 @@ const Panels: FC<PanelsProps> = ({
     const optionPanels = options.map((option) => {
         const panel = access_options[option]
         const Icon = panel.icon;
+        const panelStyle = () => {
+            if (selectedPanelKeys[panel.property]) {
+                if (selectedPanelKeys[panel.property].includes(panel.dimension)) {
+                    return "panelSelected"
+                } else {
+                    return "panelDefault"
+                }
+            } else {
+                return "panelDefault"
+            }
+        }
+        const checkMark = () => {
+            if (selectedPanelKeys[panel.property]) {
+                if (selectedPanelKeys[panel.property].includes(panel.dimension)) {
+                    return <Check className="w-3 w-3.5 max-h-6" />
+                } else {
+                    return undefined
+                }
+            } else {
+                return undefined
+            }
+        }
 
         return (
-            <Button
-                className={`flex flex-row items-center rounded-md p-3 space-x-3 bg-gray-100 text-gray-900`}
-                onClick={(e) => {
-                    toggleDimensionForPanel(panel.dimension, panel.property)
-                }}
+            <Card
+                className = { panelStyle() }
+                isPressable
+                onPress={() => toggleDimensionForPanel(panel.dimension, panel.property)}
             >
-                <div >
-                    <Icon aria-hidden={true} className="size-8" />
-                </div>
-                <div className="flex flex-row items-center sm:items-start sm:flex-col lg:flex-row lg:items-center">
-                    <div className="flex flex-col flex-0">
-                    <div className="heading-md">{panel.header}</div>
-                    <div className="body-sm">{panel.alt_description}</div>
+                <CardBody className="flex flex-row space-x-1 py-[0px] px-[0px]">
+                    <div >
+                        <Icon aria-hidden={true} className="size-8" />
                     </div>
-                </div>
-                {/* <div className="flex-1">
-                    <PiCaretRight
-                    aria-hidden={true}
-                    className={clsx("size-6", {
-                        ["invisible"]: !option.slug,
-                    })}
-                    />
-                </div> */}
-            </Button>
+                    <div className="flex flex-row items-center sm:items-start sm:flex-col lg:flex-row lg:items-center">
+                        <div className="flex flex-col flex-0">
+                        <div className="heading-md">{panel.header}</div>
+                        <div className="body-sm">{panel.alt_description}</div>
+                        </div>
+                    </div>
+                    <div >
+                        {checkMark()}
+                    </div>
+
+                </CardBody>
+            </Card>
         )
     })
 

--- a/src/components/Filters/Panels.tsx
+++ b/src/components/Filters/Panels.tsx
@@ -91,8 +91,8 @@ const Panels: FC<PanelsProps> = ({
         shadow="none"
       >
         <CardBody className="flex flex-row justify-between p-[0px]">
-          <div className="flex flex-row space-x-1">
-            <div>
+          <div className="flex flex-row">
+            <div className="mr-3">
               <Icon aria-hidden={true} className="size-8" />
             </div>
             <div className="flex flex-row items-center sm:items-start sm:flex-col lg:flex-row lg:items-center">

--- a/src/components/Filters/Panels.tsx
+++ b/src/components/Filters/Panels.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import React, { FC } from "react";
+import { Button, Card, Chip } from "@nextui-org/react";
+import { Check } from "@phosphor-icons/react";
+
+import { access_options, PropertyAccess, PropertyAccessOption } from "@/config/propertyAccessOptions";
+
+type PanelsProps = {
+    options: string[] | PropertyAccess[];
+    selectedPanelKeys: {[property: string]: string[]};
+    toggleDimensionForPanel: (dimension: string, property: string) => void;
+}
+
+const Panels: FC<PanelsProps> = ({
+    options,
+    selectedPanelKeys,
+    toggleDimensionForPanel,
+}) => {
+
+    const optionPanels = options.map((option) => {
+        const panel = access_options[option]
+        const Icon = panel.icon;
+
+        return (
+            <Button
+                className={`flex flex-row items-center rounded-md p-3 space-x-3 bg-gray-100 text-gray-900`}
+                onClick={(e) => {
+                    toggleDimensionForPanel(panel.dimension, panel.property)
+                }}
+            >
+                <div >
+                    <Icon aria-hidden={true} className="size-8" />
+                </div>
+                <div className="flex flex-row items-center sm:items-start sm:flex-col lg:flex-row lg:items-center">
+                    <div className="flex flex-col flex-0">
+                    <div className="heading-md">{panel.header}</div>
+                    <div className="body-sm">{panel.alt_description}</div>
+                    </div>
+                </div>
+                {/* <div className="flex-1">
+                    <PiCaretRight
+                    aria-hidden={true}
+                    className={clsx("size-6", {
+                        ["invisible"]: !option.slug,
+                    })}
+                    />
+                </div> */}
+            </Button>
+        )
+    })
+
+    return (
+        <div className="flex flex-col space-y-2">
+            {optionPanels}
+        </div>
+    )
+}
+
+export default Panels

--- a/src/components/Filters/Panels.tsx
+++ b/src/components/Filters/Panels.tsx
@@ -86,7 +86,7 @@ const Panels: FC<PanelsProps> = ({
         const checkMark = () => {
             if (selectedPanelKeys[panel.property]) {
                 if (selectedPanelKeys[panel.property].includes(panel.dimension)) {
-                    return <Check className="w-3 w-3.5 max-h-6" />
+                    return <Check className="self-end size-5" />
                 } else {
                     return undefined
                 }
@@ -101,21 +101,24 @@ const Panels: FC<PanelsProps> = ({
                 className = { panelStyle() }
                 isPressable
                 onPress={() => toggleDimensionForPanel(panel.dimension, panel.property)}
+                shadow="none"
             >
-                <CardBody className="flex flex-row space-x-1 py-[0px] px-[0px]">
-                    <div >
-                        <Icon aria-hidden={true} className="size-8" />
-                    </div>
-                    <div className="flex flex-row items-center sm:items-start sm:flex-col lg:flex-row lg:items-center">
-                        <div className="flex flex-col flex-0">
-                        <div className="heading-md">{panel.header}</div>
-                        <div className="body-sm">{panel.alt_description}</div>
+                <CardBody className="flex flex-row justify-between p-[0px]">
+                    <div className="flex flex-row space-x-1">
+                        <div >
+                            <Icon aria-hidden={true} className="size-8" />
                         </div>
+                        <div className="flex flex-row items-center sm:items-start sm:flex-col lg:flex-row lg:items-center">
+                            <div className="flex flex-col flex-0">
+                            <div className="heading-md">{panel.header}</div>
+                            <div className="body-sm">{panel.alt_description}</div>
+                            </div>
+                        </div>
+
                     </div>
                     <div >
                         {checkMark()}
                     </div>
-
                 </CardBody>
             </Card>
         )

--- a/src/components/Filters/Panels.tsx
+++ b/src/components/Filters/Panels.tsx
@@ -1,9 +1,8 @@
 "use client";
 
 import React, { FC } from "react";
-import { Button, Card, CardBody, Chip } from "@nextui-org/react";
+import { Card, CardBody } from "@nextui-org/react";
 import { Check } from "@phosphor-icons/react";
-
 import { access_options, PropertyAccess, PropertyAccessOption } from "@/config/propertyAccessOptions";
 
 type PanelFilterOptions = PropertyAccessOption & {

--- a/src/components/Filters/Panels.tsx
+++ b/src/components/Filters/Panels.tsx
@@ -71,34 +71,14 @@ const Panels: FC<PanelsProps> = ({
     const optionPanels = options.map((option, index) => {
         const panel = panel_access_options[option]
         const Icon = panel.icon;
-        const panelStyle = () => {
-            if (selectedPanelKeys[panel.property]) {
-                if (selectedPanelKeys[panel.property].includes(panel.dimension)) {
-                    return "panelSelected"
-                } else {
-                    return "panelDefault"
-                }
-            } else {
-                return "panelDefault"
-            }
-        }
-        const checkMark = () => {
-            if (selectedPanelKeys[panel.property]) {
-                if (selectedPanelKeys[panel.property].includes(panel.dimension)) {
-                    return <Check className="self-end size-5" />
-                } else {
-                    return undefined
-                }
-            } else {
-                return undefined
-            }
-        }
+        const isSelected = (selectedPanelKeys[panel.property] && selectedPanelKeys[panel.property].includes(panel.dimension)) ? true : false;
 
         return (
             <Card
                 key={index}
-                className = { panelStyle() }
+                className = {isSelected ? "panelSelected " : "panelDefault"}
                 isPressable
+                isHoverable={false}
                 onPress={() => toggleDimensionForPanel(panel.dimension, panel.property)}
                 shadow="none"
             >
@@ -116,7 +96,7 @@ const Panels: FC<PanelsProps> = ({
 
                     </div>
                     <div >
-                        {checkMark()}
+                        {isSelected ? <Check className="self-end size-5" /> : undefined}
                     </div>
                 </CardBody>
             </Card>

--- a/src/components/Filters/Panels.tsx
+++ b/src/components/Filters/Panels.tsx
@@ -3,111 +3,114 @@
 import React, { FC } from "react";
 import { Card, CardBody } from "@nextui-org/react";
 import { Check } from "@phosphor-icons/react";
-import { access_options, PropertyAccess, PropertyAccessOption } from "@/config/propertyAccessOptions";
+import {
+  access_options,
+  PropertyAccess,
+  PropertyAccessOption,
+} from "@/config/propertyAccessOptions";
 
 type PanelFilterOptions = PropertyAccessOption & {
-    alt_description: string;
-    dimension: string;
-    property: string;
-}
+  alt_description: string;
+  dimension: string;
+  property: string;
+};
 
 type PanelsProps = {
-    options: string[] | PropertyAccess[];
-    selectedPanelKeys: {[property: string]: string[]};
-    toggleDimensionForPanel: (dimension: string, property: string) => void;
-}
+  options: string[] | PropertyAccess[];
+  selectedPanelKeys: { [property: string]: string[] };
+  toggleDimensionForPanel: (dimension: string, property: string) => void;
+};
 
-const panel_access_options: Record<PropertyAccess | string, PanelFilterOptions> = {
-    [PropertyAccess.PRIVATE_LAND_USE]: {
-        ...access_options[PropertyAccess.PRIVATE_LAND_USE],
-        alt_description:
-        'Properties where you could get a "private land use agreement"',
-        dimension: 'Private Land Use Agreement',
-        property: 'access_process',
-    },
-    [PropertyAccess.TACTICAL_URBANISM]: {
-        ...access_options[PropertyAccess.TACTICAL_URBANISM],
-        alt_description:
-          'Properties likely safe to quickly clean without express permission',
-        dimension: 'Yes',
-        property: 'tactical_urbanism',
-      },
-      [PropertyAccess.BUY_FROM_OWNER]: {
-        ...access_options[PropertyAccess.BUY_FROM_OWNER],
-        alt_description:
-          'Properties with a market value under $1,000',
-        dimension: 'Buy Property',
-        property: 'access_process',
-      },
-      [PropertyAccess.SIDE_YARD]: {
-        ...access_options[PropertyAccess.SIDE_YARD],
-        alt_description:
-          'Properties eligible for the "Side Yard Program"',
-        dimension: 'Yes',
-        property: 'side_yard_eligible',
-      },
-      [PropertyAccess.LAND_BANK]: {
-        ...access_options[PropertyAccess.LAND_BANK],
-        alt_description:
-          'Properties available for discount prices from the Land Bank',
-        dimension: 'Land Bank',
-        property: 'access_process',
-      },
-      [PropertyAccess.CONSERVATORSHIP]: {
-        ...access_options[PropertyAccess.CONSERVATORSHIP],
-        alt_description:
-          'Abandoned and unsafe properties you can gain through a legal process',
-        dimension: 'Yes',
-        property: 'conservatorship',
-      },
-}
+const panel_access_options: Record<
+  PropertyAccess | string,
+  PanelFilterOptions
+> = {
+  [PropertyAccess.PRIVATE_LAND_USE]: {
+    ...access_options[PropertyAccess.PRIVATE_LAND_USE],
+    alt_description:
+      'Properties where you could get a "private land use agreement"',
+    dimension: "Private Land Use Agreement",
+    property: "access_process",
+  },
+  [PropertyAccess.TACTICAL_URBANISM]: {
+    ...access_options[PropertyAccess.TACTICAL_URBANISM],
+    alt_description:
+      "Properties likely safe to quickly clean without express permission",
+    dimension: "Yes",
+    property: "tactical_urbanism",
+  },
+  [PropertyAccess.BUY_FROM_OWNER]: {
+    ...access_options[PropertyAccess.BUY_FROM_OWNER],
+    alt_description: "Properties with a market value under $1,000",
+    dimension: "Buy Property",
+    property: "access_process",
+  },
+  [PropertyAccess.SIDE_YARD]: {
+    ...access_options[PropertyAccess.SIDE_YARD],
+    alt_description: 'Properties eligible for the "Side Yard Program"',
+    dimension: "Yes",
+    property: "side_yard_eligible",
+  },
+  [PropertyAccess.LAND_BANK]: {
+    ...access_options[PropertyAccess.LAND_BANK],
+    alt_description:
+      "Properties available for discount prices from the Land Bank",
+    dimension: "Land Bank",
+    property: "access_process",
+  },
+  [PropertyAccess.CONSERVATORSHIP]: {
+    ...access_options[PropertyAccess.CONSERVATORSHIP],
+    alt_description:
+      "Abandoned and unsafe properties you can gain through a legal process",
+    dimension: "Yes",
+    property: "conservatorship",
+  },
+};
 
 const Panels: FC<PanelsProps> = ({
-    options,
-    selectedPanelKeys,
-    toggleDimensionForPanel,
+  options,
+  selectedPanelKeys,
+  toggleDimensionForPanel,
 }) => {
-
-    const optionPanels = options.map((option, index) => {
-        const panel = panel_access_options[option]
-        const Icon = panel.icon;
-        const isSelected = (selectedPanelKeys[panel.property] && selectedPanelKeys[panel.property].includes(panel.dimension)) ? true : false;
-
-        return (
-            <Card
-                key={index}
-                className = {isSelected ? "panelSelected " : "panelDefault"}
-                isPressable
-                isHoverable={false}
-                onPress={() => toggleDimensionForPanel(panel.dimension, panel.property)}
-                shadow="none"
-            >
-                <CardBody className="flex flex-row justify-between p-[0px]">
-                    <div className="flex flex-row space-x-1">
-                        <div >
-                            <Icon aria-hidden={true} className="size-8" />
-                        </div>
-                        <div className="flex flex-row items-center sm:items-start sm:flex-col lg:flex-row lg:items-center">
-                            <div className="flex flex-col flex-0">
-                            <div className="heading-md">{panel.header}</div>
-                            <div className="body-sm">{panel.alt_description}</div>
-                            </div>
-                        </div>
-
-                    </div>
-                    <div >
-                        {isSelected ? <Check className="self-end size-5" /> : undefined}
-                    </div>
-                </CardBody>
-            </Card>
-        )
-    })
+  const optionPanels = options.map((option, index) => {
+    const panel = panel_access_options[option];
+    const Icon = panel.icon;
+    const isSelected =
+      selectedPanelKeys[panel.property] &&
+      selectedPanelKeys[panel.property].includes(panel.dimension)
+        ? true
+        : false;
 
     return (
-        <div className="flex flex-col space-y-2">
-            {optionPanels}
-        </div>
-    )
-}
+      <Card
+        key={index}
+        className={isSelected ? "panelSelected " : "panelDefault"}
+        isPressable
+        isHoverable={false}
+        onPress={() => toggleDimensionForPanel(panel.dimension, panel.property)}
+        shadow="none"
+      >
+        <CardBody className="flex flex-row justify-between p-[0px]">
+          <div className="flex flex-row space-x-1">
+            <div>
+              <Icon aria-hidden={true} className="size-8" />
+            </div>
+            <div className="flex flex-row items-center sm:items-start sm:flex-col lg:flex-row lg:items-center">
+              <div className="flex flex-col flex-0">
+                <div className="heading-md">{panel.header}</div>
+                <div className="body-sm">{panel.alt_description}</div>
+              </div>
+            </div>
+          </div>
+          <div>
+            {isSelected ? <Check className="self-end size-5" /> : undefined}
+          </div>
+        </CardBody>
+      </Card>
+    );
+  });
 
-export default Panels
+  return <div className="flex flex-col space-y-2">{optionPanels}</div>;
+};
+
+export default Panels;

--- a/src/config/propertyAccessOptions.tsx
+++ b/src/config/propertyAccessOptions.tsx
@@ -23,15 +23,22 @@ export interface PropertyAccessOption {
   icon: IconType | React.ComponentType<any>;
   header: string;
   description: string;
+  alt_description?: string;
+  dimension: string;
+  property: string;
   slug?: string;
 }
 
-export const access_options: Record<PropertyAccess, PropertyAccessOption> = {
+export const access_options: Record<PropertyAccess | string, PropertyAccessOption> = {
   [PropertyAccess.PRIVATE_LAND_USE]: {
     icon: PiHandshake,
     header: "Get permission from Owner",
     description:
       'Properties, given the price an owner, getting a "private land use agreement" seems best.',
+    alt_description:
+      'Properties where you could get a "private land use agreement"',
+    dimension: 'Private Land Use Agreement',
+    property: 'access_process',
     slug: "/get-access#private-land-use",
   },
   [PropertyAccess.TACTICAL_URBANISM]: {
@@ -39,12 +46,20 @@ export const access_options: Record<PropertyAccess, PropertyAccessOption> = {
     header: "Tactical Urbanism",
     description:
       "Properties likely safe enough to clean without express permission from the owner.",
+    alt_description:
+      'Properties likely safe to quickly clean without express permission',
+    dimension: 'Yes',
+    property: 'tactical_urbanism'
   },
   [PropertyAccess.BUY_FROM_OWNER]: {
     icon: PiMoney,
     header: "Buy Affordably from Owner",
     description:
       "Properties cheap enough to buy, with an estimated market value under $1,000.",
+    alt_description:
+      'Properties with a market value under $1,000',
+    dimension: 'Buy Property',
+    property: 'access_process',
     slug: "/get-access#buy-from-owner",
   },
   [PropertyAccess.SIDE_YARD]: {
@@ -52,6 +67,10 @@ export const access_options: Record<PropertyAccess, PropertyAccessOption> = {
     header: "Purchase as a Side Yard",
     description:
       'If you live next to this property, you may purchase this through the "Side Yard Programs"',
+    alt_description:
+      'Properties eligible for the "Side Yard Program"',
+    dimension: 'Yes',
+    property: 'side_yard_eligible',
     slug: "/get-access#side-yard",
   },
   [PropertyAccess.LAND_BANK]: {
@@ -59,6 +78,10 @@ export const access_options: Record<PropertyAccess, PropertyAccessOption> = {
     header: "Gain through Land Bank",
     description:
       "Properties owned by the Land Bank and available to buy with discounted prices.",
+    alt_description:
+      'Properties available for discount prices from the Land Bank',
+    dimension: 'Land Bank',
+    property: 'access_process',
     slug: "/get-access#land-bank",
   },
   [PropertyAccess.CONSERVATORSHIP]: {
@@ -66,6 +89,10 @@ export const access_options: Record<PropertyAccess, PropertyAccessOption> = {
     header: "Get Through Conservatorship",
     description:
       'Properties, abandoned and unsafe, which can be gained through a legal "conservatorship"',
+    alt_description:
+      'Abandoned and unsafe properties you can gain through a legal process',
+    dimension: 'Yes',
+    property: 'conservatorship',
     slug: "/get-access#conservatorship",
   },
   [PropertyAccess.DO_NOTHING]: {
@@ -73,6 +100,8 @@ export const access_options: Record<PropertyAccess, PropertyAccessOption> = {
     header: "Do Nothing",
     description:
       "We believe access this property legally is too complicated to justify the effort.",
+    dimension: "",
+    property: "",
     slug: "/get-access#do-nothing",
   },
 };

--- a/src/config/propertyAccessOptions.tsx
+++ b/src/config/propertyAccessOptions.tsx
@@ -23,22 +23,15 @@ export interface PropertyAccessOption {
   icon: IconType | React.ComponentType<any>;
   header: string;
   description: string;
-  alt_description?: string;
-  dimension: string;
-  property: string;
   slug?: string;
 }
 
-export const access_options: Record<PropertyAccess | string, PropertyAccessOption> = {
+export const access_options: Record<PropertyAccess, PropertyAccessOption> = {
   [PropertyAccess.PRIVATE_LAND_USE]: {
     icon: PiHandshake,
     header: "Get permission from Owner",
     description:
       'Properties, given the price an owner, getting a "private land use agreement" seems best.',
-    alt_description:
-      'Properties where you could get a "private land use agreement"',
-    dimension: 'Private Land Use Agreement',
-    property: 'access_process',
     slug: "/get-access#private-land-use",
   },
   [PropertyAccess.TACTICAL_URBANISM]: {
@@ -46,20 +39,12 @@ export const access_options: Record<PropertyAccess | string, PropertyAccessOptio
     header: "Tactical Urbanism",
     description:
       "Properties likely safe enough to clean without express permission from the owner.",
-    alt_description:
-      'Properties likely safe to quickly clean without express permission',
-    dimension: 'Yes',
-    property: 'tactical_urbanism'
   },
   [PropertyAccess.BUY_FROM_OWNER]: {
     icon: PiMoney,
     header: "Buy Affordably from Owner",
     description:
       "Properties cheap enough to buy, with an estimated market value under $1,000.",
-    alt_description:
-      'Properties with a market value under $1,000',
-    dimension: 'Buy Property',
-    property: 'access_process',
     slug: "/get-access#buy-from-owner",
   },
   [PropertyAccess.SIDE_YARD]: {
@@ -67,10 +52,6 @@ export const access_options: Record<PropertyAccess | string, PropertyAccessOptio
     header: "Purchase as a Side Yard",
     description:
       'If you live next to this property, you may purchase this through the "Side Yard Programs"',
-    alt_description:
-      'Properties eligible for the "Side Yard Program"',
-    dimension: 'Yes',
-    property: 'side_yard_eligible',
     slug: "/get-access#side-yard",
   },
   [PropertyAccess.LAND_BANK]: {
@@ -78,10 +59,6 @@ export const access_options: Record<PropertyAccess | string, PropertyAccessOptio
     header: "Gain through Land Bank",
     description:
       "Properties owned by the Land Bank and available to buy with discounted prices.",
-    alt_description:
-      'Properties available for discount prices from the Land Bank',
-    dimension: 'Land Bank',
-    property: 'access_process',
     slug: "/get-access#land-bank",
   },
   [PropertyAccess.CONSERVATORSHIP]: {
@@ -89,10 +66,6 @@ export const access_options: Record<PropertyAccess | string, PropertyAccessOptio
     header: "Get Through Conservatorship",
     description:
       'Properties, abandoned and unsafe, which can be gained through a legal "conservatorship"',
-    alt_description:
-      'Abandoned and unsafe properties you can gain through a legal process',
-    dimension: 'Yes',
-    property: 'conservatorship',
     slug: "/get-access#conservatorship",
   },
   [PropertyAccess.DO_NOTHING]: {
@@ -100,8 +73,6 @@ export const access_options: Record<PropertyAccess | string, PropertyAccessOptio
     header: "Do Nothing",
     description:
       "We believe access this property legally is too complicated to justify the effort.",
-    dimension: "",
-    property: "",
     slug: "/get-access#do-nothing",
   },
 };


### PR DESCRIPTION
This PR request combines the "Access Process", "Conservatorship Eligible", "Side Yard Eligible", and "Tactical Urbanism" into one, new filter section titled "Get Access" which contains six selectable panels: three for access process (private land use agreement, buy from owner, and get from land bank) and one each for conservatorship, side yard, and tactical urbanism.

This PR addresses issue #581 

@thansidwell and @paulhchoi, I have made frontend changes for review in this PR

Some things to note for the reviewers' consideration:

- The 'Find only when its the best option' button from the prototype has not been included because it doesn't seem to add functionality to the filter.  See discussion in issue #581 

- The new panel filter has different functionality than the previous Yes/No button filters for conservatorships, side yards, and tactical urbanism.  In the panel filter, selecting one of those options filters for the "Yes" condition of those options.  Deselecting the option returns the map to showing properties that satisfy either the Yes or No conditions for that option.  A user cannot choose to see the properties where those options aren't available.

- The "Get Access" filter reuses the icons and titles from the "Getting Access" section of the property detail view.  The titles don't exactly match the "Get Access" panel titles in the prototype, but I thought reusing them would be good for continuity.  I'm no longer sure that level of continuity makes a difference, so I won't argue against changing the titles.  I kept the matching titles for this PR for two reasons: it gives me more mileage out of extending `PanelFilterOptions`, which is a cool new trick for me, and I thought it would be easier to point out the difference in phrasing this way.  I'll change the panel titles to what was planned in the prototype if that is preferred.

- There is not a smooth transition in color between the default, hover, and selected states of the panels, especially when a selected panel is deselected.  I think I see the same issue happening on the other filter buttons, but it is more pronounced on the large panels.  Any suggestions on how to reduce or eliminate the flickering effect would be appreciated.

